### PR TITLE
pool should always come from client

### DIFF
--- a/calicoctl/calico_ctl/container.py
+++ b/calicoctl/calico_ctl/container.py
@@ -32,7 +32,7 @@ from subprocess import CalledProcessError
 from netaddr import IPAddress, IPNetwork
 from calico_ctl import endpoint
 from pycalico import netns
-from pycalico.datastore_datatypes import IPPool, Endpoint
+from pycalico.datastore_datatypes import Endpoint
 from pycalico.ipam import AlreadyAssignedError
 
 from connectors import client

--- a/calicoctl/calico_ctl/container.py
+++ b/calicoctl/calico_ctl/container.py
@@ -507,7 +507,7 @@ def get_ip_and_pool(ip):
         pool = get_pool_or_exit(ip)
     elif ip is not None and '/' in ip:
         cidr = IPNetwork(ip)
-        pool = get_pool_or_exit(IPAddress(cidr.first))
+        pool = get_pool_by_cidr_or_exit(cidr)
         if IPNetwork(ip).version == 4:
             result = assign_any(1, 0, pool=(pool, None))
             ip = result[0][0]
@@ -529,6 +529,15 @@ def get_ip_and_pool(ip):
             sys.exit(1)
 
     return (ip, pool)
+
+
+def get_pool_by_cidr_or_exit(cidr):
+    pools = client.get_ip_pools(cidr.version)
+    for pool in pools:
+        if pool.cidr == cidr:
+            return pool
+    print "%s is not found" % cidr
+    sys.exit(1)
 
 
 def get_pool_or_exit(ip):

--- a/calicoctl/calico_ctl/container.py
+++ b/calicoctl/calico_ctl/container.py
@@ -507,7 +507,7 @@ def get_ip_and_pool(ip):
         pool = get_pool_or_exit(ip)
     elif ip is not None and '/' in ip:
         cidr = IPNetwork(ip)
-        pool = client.get_pool(IPAddress(cidr.first))
+        pool = get_pool_or_exit(IPAddress(cidr.first))
         if IPNetwork(ip).version == 4:
             result = assign_any(1, 0, pool=(pool, None))
             ip = result[0][0]

--- a/calicoctl/calico_ctl/container.py
+++ b/calicoctl/calico_ctl/container.py
@@ -32,7 +32,7 @@ from subprocess import CalledProcessError
 from netaddr import IPAddress, IPNetwork
 from calico_ctl import endpoint
 from pycalico import netns
-from pycalico.datastore_datatypes import Endpoint
+from pycalico.datastore_datatypes import IPPool, Endpoint
 from pycalico.ipam import AlreadyAssignedError
 
 from connectors import client

--- a/calicoctl/calico_ctl/container.py
+++ b/calicoctl/calico_ctl/container.py
@@ -32,7 +32,7 @@ from subprocess import CalledProcessError
 from netaddr import IPAddress, IPNetwork
 from calico_ctl import endpoint
 from pycalico import netns
-from pycalico.datastore_datatypes import IPPool, Endpoint
+from pycalico.datastore_datatypes import Endpoint
 from pycalico.ipam import AlreadyAssignedError
 
 from connectors import client
@@ -506,7 +506,8 @@ def get_ip_and_pool(ip):
             ip = result[1][0]
         pool = get_pool_or_exit(ip)
     elif ip is not None and '/' in ip:
-        pool = IPPool(ip)
+        cidr = IPNetwork(ip)
+        pool = client.get_pool(IPAddress(cidr.first))
         if IPNetwork(ip).version == 4:
             result = assign_any(1, 0, pool=(pool, None))
             ip = result[0][0]

--- a/calicoctl/tests/unit/container_test.py
+++ b/calicoctl/tests/unit/container_test.py
@@ -548,9 +548,10 @@ class TestContainer(unittest.TestCase):
     @patch('calico_ctl.container.get_container_info_or_exit', autospec=True)
     @patch('calico_ctl.container.client', autospec=True)
     @patch('calico_ctl.container.netns', autospec=True)
+    @patch('calico_ctl.container.get_pool_or_exit', autospec=True)
     def test_container_ip_add_ipv4_pool(
-            self, m_netns, m_client, m_get_container_info_or_exit,
-            m_enforce_root):
+            self, m_get_pool_or_exit, m_netns, m_client,
+            m_get_container_info_or_exit, m_enforce_root):
         """
         Test for container_ip_add with an CIDR/pool ip argument
 
@@ -564,7 +565,7 @@ class TestContainer(unittest.TestCase):
 
         m_client.get_endpoint.return_value = m_endpoint
         m_client.auto_assign_ips.return_value = ([ip_addr], [])
-        m_client.get_pool.return_value = pool_return
+        m_get_pool_or_exit.return_value = pool_return
         m_get_container_info_or_exit.return_value = {
             'Id': 666,
             'State': {'Running': 1, 'Pid': 'Pid_info'}

--- a/calicoctl/tests/unit/container_test.py
+++ b/calicoctl/tests/unit/container_test.py
@@ -548,9 +548,9 @@ class TestContainer(unittest.TestCase):
     @patch('calico_ctl.container.get_container_info_or_exit', autospec=True)
     @patch('calico_ctl.container.client', autospec=True)
     @patch('calico_ctl.container.netns', autospec=True)
-    @patch('calico_ctl.container.get_pool_or_exit', autospec=True)
+    @patch('calico_ctl.container.get_pool_by_cidr_or_exit', autospec=True)
     def test_container_ip_add_ipv4_pool(
-            self, m_get_pool_or_exit, m_netns, m_client,
+            self, m_get_pool_by_cidr_or_exit, m_netns, m_client,
             m_get_container_info_or_exit, m_enforce_root):
         """
         Test for container_ip_add with an CIDR/pool ip argument
@@ -565,7 +565,7 @@ class TestContainer(unittest.TestCase):
 
         m_client.get_endpoint.return_value = m_endpoint
         m_client.auto_assign_ips.return_value = ([ip_addr], [])
-        m_get_pool_or_exit.return_value = pool_return
+        m_get_pool_by_cidr_or_exit.return_value = pool_return
         m_get_container_info_or_exit.return_value = {
             'Id': 666,
             'State': {'Running': 1, 'Pid': 'Pid_info'}

--- a/calicoctl/tests/unit/container_test.py
+++ b/calicoctl/tests/unit/container_test.py
@@ -22,7 +22,7 @@ from subprocess import CalledProcessError
 from calico_ctl.bgp import *
 from calico_ctl import container
 from calico_ctl import utils
-from pycalico.datastore_datatypes import Endpoint, IPPool
+from pycalico.datastore_datatypes import Endpoint
 from pycalico.ipam import AlreadyAssignedError
 
 
@@ -545,13 +545,12 @@ class TestContainer(unittest.TestCase):
                                                           interface)
 
     @patch('calico_ctl.container.enforce_root', autospec=True)
-    @patch('calico_ctl.container.IPPool', autospec=True)
     @patch('calico_ctl.container.get_container_info_or_exit', autospec=True)
     @patch('calico_ctl.container.client', autospec=True)
     @patch('calico_ctl.container.netns', autospec=True)
     def test_container_ip_add_ipv4_pool(
             self, m_netns, m_client, m_get_container_info_or_exit,
-            m_ippool, m_enforce_root):
+            m_enforce_root):
         """
         Test for container_ip_add with an CIDR/pool ip argument
 
@@ -565,7 +564,7 @@ class TestContainer(unittest.TestCase):
 
         m_client.get_endpoint.return_value = m_endpoint
         m_client.auto_assign_ips.return_value = ([ip_addr], [])
-        m_ippool.return_value = pool_return
+        m_client.get_pool.return_value = pool_return
         m_get_container_info_or_exit.return_value = {
             'Id': 666,
             'State': {'Running': 1, 'Pid': 'Pid_info'}
@@ -584,7 +583,6 @@ class TestContainer(unittest.TestCase):
         # Assert
         self.assertFalse(m_client.assign_ip.called)
         m_enforce_root.assert_called_once_with()
-        m_ippool.assert_called_once_with(ip)
         m_get_container_info_or_exit.assert_called_once_with(container_name)
         m_client.get_endpoint.assert_called_once_with(
             hostname=utils.hostname,

--- a/calicoctl/tests/unit/utils_test.py
+++ b/calicoctl/tests/unit/utils_test.py
@@ -50,8 +50,6 @@ class TestUtils(unittest.TestCase):
         ('aa:bb::ff', 4, False),
         ('aa:bb::ff', 6, True),
         ('1111:2222:3333:4444:5555:6666:7777:8888', 6, True),
-        ('4294967295', 4, True),
-        ('5000000000', 4, False)
     ])
     def test_validate_ip(self, ip, version, expected_result):
         """


### PR DESCRIPTION
may fix [this](https://github.com/projectcalico/libcalico/issues/68)

when comparing two IPPools, values should be specified, if create one IPPool, `masquerade`, `ipip`, `ipam` may not be the same as stored in etcd.