### PR TITLE
Rename calico-docker to calico-containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!--- master only -->
-[![Build Status](https://semaphoreci.com/api/v1/projects/9d7d365d-19cb-4699-8c84-b76da25ae271/473490/shields_badge.svg)](https://semaphoreci.com/calico/calico-containers--5)
+[![Build Status](https://semaphoreci.com/api/v1/projects/9d7d365d-19cb-4699-8c84-b76da25ae271/473490/shields_badge.svg)](https://semaphoreci.com/calico/calico-docker--5)
 [![CircleCI branch](https://img.shields.io/circleci/project/projectcalico/calico-containers/master.svg?label=calicoctl)](https://circleci.com/gh/projectcalico/calico-containers/tree/master)
-[![Coverage Status](https://coveralls.io/repos/projectcalico/calico-containers/badge.svg?branch=master&service=github)](https://coveralls.io/github/projectcalico/calico-containers?branch=master)
+[![Coverage Status](https://coveralls.io/repos/projectcalico/calico-containers/badge.svg?branch=master&service=github)](https://coveralls.io/github/projectcalico/calico-docker?branch=master)
 [![Docker Pulls](https://img.shields.io/docker/pulls/calico/node.svg)](https://hub.docker.com/r/calico/node/)
 [![](https://badge.imagelayers.io/calico/node:latest.svg)](https://imagelayers.io/?images=calico/node:latest)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!--- master only -->
-[![Build Status](https://semaphoreci.com/api/v1/projects/9d7d365d-19cb-4699-8c84-b76da25ae271/473490/shields_badge.svg)](https://semaphoreci.com/calico/calico-docker--5)
-[![CircleCI branch](https://img.shields.io/circleci/project/projectcalico/calico-containers/master.svg?label=calicoctl)](https://circleci.com/gh/projectcalico/calico-docker/tree/master)
-[![Coverage Status](https://coveralls.io/repos/projectcalico/calico-docker/badge.svg?branch=master&service=github)](https://coveralls.io/github/projectcalico/calico-docker?branch=master)
+[![Build Status](https://semaphoreci.com/api/v1/projects/9d7d365d-19cb-4699-8c84-b76da25ae271/473490/shields_badge.svg)](https://semaphoreci.com/calico/calico-containers--5)
+[![CircleCI branch](https://img.shields.io/circleci/project/projectcalico/calico-containers/master.svg?label=calicoctl)](https://circleci.com/gh/projectcalico/calico-containers/tree/master)
+[![Coverage Status](https://coveralls.io/repos/projectcalico/calico-containers/badge.svg?branch=master&service=github)](https://coveralls.io/github/projectcalico/calico-containers?branch=master)
 [![Docker Pulls](https://img.shields.io/docker/pulls/calico/node.svg)](https://hub.docker.com/r/calico/node/)
 [![](https://badge.imagelayers.io/calico/node:latest.svg)](https://imagelayers.io/?images=calico/node:latest)
 
@@ -49,7 +49,7 @@ We welcome questions/comments/feedback (and pull requests).
 * [Slack Calico Users Channel](https://calicousers.slack.com) ([Sign up](https://calicousers-slackin.herokuapp.com))
 * IRC - [#calico](https://kiwiirc.com/client/irc.freenode.net/#calico)
 * For issues related to Calico in a containerized environment, please 
-[raise issues](https://github.com/projectcalico/calico-docker/issues/new) on 
+[raise issues](https://github.com/projectcalico/calico-containers/issues/new) on 
 GitHub.
 
 ## Getting started
@@ -95,10 +95,10 @@ the material listed below.
     - [Calico Repositories](docs/RepoStructure.md) to see the
       collection of Calico related respoitories that collectively provide the
       networking, tools, and orchestration integrations.
-    - [Building and testing calico-docker images](docs/Building.md) to build a Calico setup on your local 
+    - [Building and testing calico-containers images](docs/Building.md) to build a Calico setup on your local 
       machine for development and testing 
   - **FAQ and Troubleshooting**
     - [FAQ](docs/FAQ.md)
     - [Troubleshooting](docs/Troubleshooting.md)
 
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/README.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/README.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/calico_node/filesystem/README.md
+++ b/calico_node/filesystem/README.md
@@ -4,4 +4,4 @@ This directory will be copied onto the root of the calico-node container's
 filesystem.
 
 It contains config files and templates for Bird, confd.
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/calico_node/filesystem/README.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/calico_node/filesystem/README.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/calico_node/filesystem/etc/calico/confd/templates/README.md
+++ b/calico_node/filesystem/etc/calico/confd/templates/README.md
@@ -44,4 +44,4 @@ Referenced by the confd-generated bird.toml and bird6.toml files.
 
 These templates write out the main BIRD configuration when the full 
 node-to-node mesh is disabled.
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/calico_node/filesystem/templates/README.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/calico_node/filesystem/templates/README.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/calicoctl/calico_ctl/utils.py
+++ b/calicoctl/calico_ctl/utils.py
@@ -26,7 +26,7 @@ from netaddr.core import AddrFormatError
 
 DOCKER_VERSION = "1.16"
 DOCKER_LIBNETWORK_VERSION = "1.21"
-# There is an issue with 2.0.9 and CAS (when using py-etcd) - https://github.com/projectcalico/calico-docker/issues/479
+# There is an issue with 2.0.9 and CAS (when using py-etcd) - https://github.com/projectcalico/calico-containers/issues/479
 ETCD_VERSION = "2.0.10"
 DOCKER_ORCHESTRATOR_ID = "docker"
 NAMESPACE_ORCHESTRATOR_ID = "namespace"

--- a/calicoctl/calicoctl.py
+++ b/calicoctl/calicoctl.py
@@ -60,7 +60,7 @@ from calico_ctl.utils import print_paragraph
 
 # TODO: Implement secure platform support for urllib3. Temporarily ignore
 # insecure platform warnings when running calicoctl commands with secure etcd.
-# See https://github.com/projectcalico/calico-docker/issues/682
+# See https://github.com/projectcalico/calico-containers/issues/682
 import logging
 logging.captureWarnings(True)
 

--- a/docs/AdvancedNetworkPolicy.md
+++ b/docs/AdvancedNetworkPolicy.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # Advanced Network Policy
@@ -143,4 +143,4 @@ Verify the tag was accepted by running
     WEB
     APP_7890
 
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/AdvancedNetworkPolicy.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/AdvancedNetworkPolicy.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/Building.md
+++ b/docs/Building.md
@@ -1,12 +1,12 @@
 <!--- master only -->
-> ![warning](images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.13.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.13.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
-# Building and testing calico-docker images
+# Building and testing calico-containers images
 
 This document describes how to build the `calicoctl` binary and the `calico/node` Docker image, and how to run the Calico Docker test suites.
 
@@ -148,4 +148,4 @@ To run the single no-orchestrator, mainline multi-host test:
 
     sudo ST_TO_RUN=calico_containers/tests/st/no_orchestrator/test_mainline_multi_host.py make st
 
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/Building.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/Building.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/Components.md
+++ b/docs/Components.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # Anatomy of a calico-node container
@@ -78,4 +78,4 @@ For a detailed look at how each component works when adding Docker containers
 to Calico networking, check out the [Lifecycle of a Docker Default Container]
 (./DockerContainerLifecycle.md) page.
 
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/Components.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/Components.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/DockerContainerLifecycle.md
+++ b/docs/DockerContainerLifecycle.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # Lifecycle of a container (Calico without Docker networking)
@@ -200,4 +200,4 @@ other.
 
 ![calicoctl container set profile](images/lifecycle/set_profile.png)
 
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/DockerContainerLifecycle.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/DockerContainerLifecycle.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/DockerlessCalicoManual.md
+++ b/docs/DockerlessCalicoManual.md
@@ -55,7 +55,7 @@ Please raise any encountered issues, or message us on [calico-slack](https://cal
 7. Install the additional binaries for Dockerless-calico:
     ```
     # calicoctl
-    curl -L https://github.com/projectcalico/calico-docker/releases/download/v0.13.0/calicoctl -o /usr/local/bin/calicoctl
+    curl -L https://github.com/projectcalico/calico-containers/releases/download/v0.13.0/calicoctl -o /usr/local/bin/calicoctl
     chmod +x /usr/local/bin/calicoctl
     
     # bird
@@ -108,4 +108,4 @@ systemctl start calico-dockerless
 ```
 
 [libvirt-wiki]: http://wiki.libvirt.org/page/Guest_won%27t_start_-_warning:_could_not_open_/dev/net/tun_%28%27generic_ethernet%27_interface%29
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/DockerlessCalicoManual.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/DockerlessCalicoManual.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/EtcdSecureCluster.md
+++ b/docs/EtcdSecureCluster.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](./images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](./images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # Using Calico with a secure etcd cluster
@@ -86,4 +86,4 @@ command line options to the Docker daemon.
      --cluster-store-opt kv.certfile=/path/to/cert.crt
      --cluster-store-opt kv.keyfile=/path/to/key.pem
 
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/EtcdSecureCluster.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/EtcdSecureCluster.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/ExternalConnectivity.md
+++ b/docs/ExternalConnectivity.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # External Connectivity - Hosts on their own Layer 2 segment
@@ -55,4 +55,4 @@ detailed datacenter networking recommendations are given in the main
 [Project Calico documentation](http://docs.projectcalico.org/en/latest/index.html).
 We'd also encourage you to [get in touch](http://www.projectcalico.org/contact/)
 to discuss your environment.
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/ExternalConnectivity.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/ExternalConnectivity.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # Frequently Asked Questions
@@ -102,4 +102,4 @@ Yes.  If you are running in a public cloud that doesn't allow either L3 peering 
 ./calicoctl pool add <CIDR> --ipip --nat-outgoing
 ```
 Calico will then route traffic between Calico hosts using IP in IP.
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/FAQ.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/FAQ.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/RepoStructure.md
+++ b/docs/RepoStructure.md
@@ -1,14 +1,14 @@
 <!--- master only -->
-> ![warning](images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # Calico Repositories
 
-## The calico-docker repository
+## The calico-containers repository
 
 This respository contains the following:
 
@@ -26,7 +26,7 @@ This respository contains the following:
   Calico with Docker.  The [`calico_test` directory](../calico_test) contains 
   the Docker file and associated files for the `calico/test image`.  This 
   includes a set of utility Python files for running STs.  This image is used 
-  by the calico-docker STs and UTs.
+  by the calico-containers STs and UTs.
 - UTs testing calicoctl, STs testing single host and multihost systems
   using calicoctl and calico/node to create Calico networked containers.  These
   tests run within the `calico/test` Docker image.  See the [`tests` directory](../tests)
@@ -87,4 +87,4 @@ integrations.
    Docker image (available on DockerHub).  When Calico node is started with the
    `--libnetwork` flag, a separate container is launched running the driver.
 
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/RepoStructure.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/RepoStructure.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # Troubleshooting
@@ -45,4 +45,4 @@ recommend doing a `vagrant destroy; vagrant up` to start from a clean slate afte
 
 If you hit issues, please raise tickets. Diags can be collected with the 
 `sudo ./calicoctl diags` command.
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/Troubleshooting.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/Troubleshooting.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/bgp.md
+++ b/docs/bgp.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # BGP Configuration
@@ -228,4 +228,4 @@ the following command from the "Node1" command line:
 	|   aa:bb::ff  | node-to-node mesh |   up  | 16:17:26 | Established |
 	+--------------+-------------------+-------+----------+-------------+
 
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/bgp.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/bgp.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/calico-with-docker/AWS.md
+++ b/docs/calico-with-docker/AWS.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](../images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](../images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # Running the Calico tutorials on AWS
@@ -341,4 +341,4 @@ traffic between your Calico containers.
 
 [install-aws-cli]: http://docs.aws.amazon.com/cli/latest/userguide/installing.html#install-bundle-other-os
 [configure-aws-cli]: http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-calico-with-docker.html
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/calico-with-docker/AWS.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/calico-with-docker/AWS.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/calico-with-docker/DigitalOcean.md
+++ b/docs/calico-with-docker/DigitalOcean.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](../images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](../images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # Running the Calico tutorials on DigitalOcean
@@ -135,4 +135,4 @@ curl http://<host public ip>:80
 ```
 
 [coreos-digitalocean]: https://coreos.com/docs/running-coreos/cloud-providers/digitalocean/
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/calico-with-docker/DigitalOcean.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/calico-with-docker/DigitalOcean.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/calico-with-docker/GCE.md
+++ b/docs/calico-with-docker/GCE.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](../images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](../images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # Running the Calico tutorials on GCE
@@ -168,4 +168,4 @@ curl http://<host public ip>:80
 
 [coreos-gce]: https://coreos.com/docs/running-coreos/cloud-providers/google-compute-engine/
 [gcloud-instructions]: https://cloud.google.com/compute/docs/gcloud-compute/
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/calico-with-docker/GCE.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/calico-with-docker/GCE.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/calico-with-docker/VagrantCoreOS.md
+++ b/docs/calico-with-docker/VagrantCoreOS.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](../images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](../images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # Running the Calico tutorials on CoreOS using Vagrant and VirtualBox
@@ -22,11 +22,11 @@ These instructions allow you to set up a CoreOS cluster ready to network Docker 
 <!--- master only -->
 ### 1.2 Clone this project
 
-    git clone https://github.com/projectcalico/calico-docker.git
+    git clone https://github.com/projectcalico/calico-containers.git
 <!--- else
 ### 1.2 Clone this project, and checkout the **release** release
 
-    git clone https://github.com/projectcalico/calico-docker.git
+    git clone https://github.com/projectcalico/calico-containers.git
     git checkout tags/**release**
 <!--- end of master only -->
     
@@ -38,11 +38,11 @@ by changing into the appropriate directory.
 
 For Calico as a Docker network plugin
   
-    cd calico-docker/docs/calico-with-docker/docker-network-plugin/vagrant-coreos
+    cd calico-containers/docs/calico-with-docker/docker-network-plugin/vagrant-coreos
 
 For Calico without Docker networking
   
-    cd calico-docker/docs/calico-with-docker/without-docker-networking/vagrant-coreos
+    cd calico-containers/docs/calico-with-docker/without-docker-networking/vagrant-coreos
        
 Run
 
@@ -93,9 +93,9 @@ the networking option that you chose in step (3).
 - [Calico without Docker networking walkthrough](without-docker-networking/README.md)  
 
 
-[calico-networking]: https://github.com/projectcalico/calico-docker
+[calico-networking]: https://github.com/projectcalico/calico-containers
 [virtualbox]: https://www.virtualbox.org/
 [vagrant]: https://www.vagrantup.com/downloads.html
 [using-coreos]: http://coreos.com/docs/using-coreos/
 [git]: http://git-scm.com/
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/calico-with-docker/VagrantCoreOS.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/calico-with-docker/VagrantCoreOS.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/calico-with-docker/VagrantUbuntu.md
+++ b/docs/calico-with-docker/VagrantUbuntu.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](../images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](../images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # Running the Calico tutorials on Ubuntu using Vagrant and VirtualBox
@@ -22,11 +22,11 @@ These instructions allow you to set up an Ubuntu cluster ready to network Docker
 <!--- master only -->
 ### 1.2 Clone this project
 
-    git clone https://github.com/projectcalico/calico-docker.git
+    git clone https://github.com/projectcalico/calico-containers.git
 <!--- else
 ### 1.2 Clone this project, and checkout the **release** release
 
-    git clone https://github.com/projectcalico/calico-docker.git
+    git clone https://github.com/projectcalico/calico-containers.git
     git checkout tags/**release**
 <!--- end of master only -->
     
@@ -38,11 +38,11 @@ by changing into the appropriate directory.
 
 For Calico as a Docker network plugin
   
-    cd calico-docker/docs/calico-with-docker/docker-network-plugin/vagrant-ubuntu
+    cd calico-containers/docs/calico-with-docker/docker-network-plugin/vagrant-ubuntu
 
 For Calico without Docker networking
   
-    cd calico-docker/docs/calico-with-docker/without-docker-networking/vagrant-ubuntu
+    cd calico-containers/docs/calico-with-docker/without-docker-networking/vagrant-ubuntu
         
 Use vagrant to create and boot your VMs.
 
@@ -97,5 +97,5 @@ the networking option that you chose in step (3).
 [virtualbox]: https://www.virtualbox.org/
 [vagrant]: https://www.vagrantup.com/downloads.html
 [git]: http://git-scm.com/
-[calico-networking]: https://github.com/projectcalico/calico-docker
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/calico-with-docker/VagrantUbuntu.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[calico-networking]: https://github.com/projectcalico/calico-containers
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/calico-with-docker/VagrantUbuntu.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/calico-with-docker/docker-network-plugin/AdvancedPolicy.md
+++ b/docs/calico-with-docker/docker-network-plugin/AdvancedPolicy.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](../../images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](../../images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # Accessing Calico policy with Calico as a network plugin
@@ -111,4 +111,4 @@ here we can display the rules that are contained in the profile:
 For more details about advanced policy options read the 
 [Advanced Network Policy tutorial](../../AdvancedNetworkPolicy.md).
 
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/calico-with-docker/docker-network-plugin/AdvancedPolicy.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/calico-with-docker/docker-network-plugin/AdvancedPolicy.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/calico-with-docker/docker-network-plugin/CalicoSwarm.md
+++ b/docs/calico-with-docker/docker-network-plugin/CalicoSwarm.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](../../images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](../../images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # Running Calico on a Docker Swarm
@@ -164,4 +164,4 @@ B. These pings should fail.
 
     $ export WORKLOADB_IP=`docker -H $MANAGER_IP:$SWARM_PORT inspect --format "{{ .NetworkSettings.Networks.net2.IPAddress }}" workload-B`
     $ docker -H $MANAGER_IP:$SWARM_PORT exec workload-A ping -c 4 $WORKLOADB_IP
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/calico-with-docker/docker-network-plugin/CalicoSwarm.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/calico-with-docker/docker-network-plugin/CalicoSwarm.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/calico-with-docker/docker-network-plugin/IPv6.md
+++ b/docs/calico-with-docker/docker-network-plugin/IPv6.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](../../images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](../../images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # Calico IPv6 networking as a Docker network plugin (Optional)
@@ -162,4 +162,4 @@ To see the list of networks, use
 
     docker network ls
 
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/calico-with-docker/docker-network-plugin/IPv6.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/calico-with-docker/docker-network-plugin/IPv6.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/calico-with-docker/docker-network-plugin/ManualSetup.md
+++ b/docs/calico-with-docker/docker-network-plugin/ManualSetup.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](../../images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](../../images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # Preparing the environment for Calico as a Docker network plugin
@@ -108,7 +108,7 @@ With the environment set up, you can run through the remainder of the worked
 example in the [Calico as a Docker network plugin tutorial](README.md).
     
 [etcd]: https://coreos.com/etcd/docs/latest/
-[calico-releases]: https://github.com/projectcalico/calico-docker/releases/
+[calico-releases]: https://github.com/projectcalico/calico-containers/releases/
 [docker]: https://docs.docker.com/installation/
 
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/calico-with-docker/docker-network-plugin/ManualSetup.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/calico-with-docker/docker-network-plugin/ManualSetup.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/calico-with-docker/docker-network-plugin/README.md
+++ b/docs/calico-with-docker/docker-network-plugin/README.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](../../images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](../../images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # Calico as a Docker network plugin.
@@ -266,4 +266,4 @@ learn more about Calico under-the-covers please refer to the
 [Further Reading](../../../README.md#further-reading) section on the main
 documentation README.
 
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/calico-with-docker/docker-network-plugin/README.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/calico-with-docker/docker-network-plugin/README.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/calico-with-docker/without-docker-networking/IPv6.md
+++ b/docs/calico-with-docker/without-docker-networking/IPv6.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](../../images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](../../images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # Calico IPv6 networking without Docker networking (Optional)
@@ -105,4 +105,4 @@ Now you can ping between the two containers using their IPv6 addresses.
 On calico-02:
 
     docker exec workload-G ping6 -c 4 fd80:24e2:f998:72d6::1
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/calico-with-docker/without-docker-networking/IPv6.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/calico-with-docker/without-docker-networking/IPv6.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/calico-with-docker/without-docker-networking/ManualSetup.md
+++ b/docs/calico-with-docker/without-docker-networking/ManualSetup.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](../../images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](../../images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # Preparing the environment for Calico without Docker networking
@@ -88,6 +88,6 @@ With the environment set up, you can run through the remainder of the worked
 example in the [Calico without Docker networking tutorial](README.md).
 
 [etcd]: https://coreos.com/etcd/docs/latest/
-[calico-releases]: https://github.com/projectcalico/calico-docker/releases/
+[calico-releases]: https://github.com/projectcalico/calico-containers/releases/
 [docker]: http://www.docker.com
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/calico-with-docker/without-docker-networking/ManualSetup.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/calico-with-docker/without-docker-networking/ManualSetup.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/calico-with-docker/without-docker-networking/README.md
+++ b/docs/calico-with-docker/without-docker-networking/README.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](../../images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](../../images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # Calico without Docker networking (i.e. `--net=none`)
@@ -175,4 +175,4 @@ learn more about Calico under-the-covers please refer to the
 [Further Reading](../../../README.md#further-reading) section on the main
 documentation README.
 
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/calico-with-docker/without-docker-networking/README.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/calico-with-docker/without-docker-networking/README.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/calicoctl.md
+++ b/docs/calicoctl.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # calicoctl command line interface user reference
@@ -68,4 +68,4 @@ organized by top level command.
 -  [calicoctl version](calicoctl/version.md)
 -  [calicoctl config](calicoctl/config.md)
 
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/calicoctl.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/calicoctl.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/calicoctl/bgp.md
+++ b/docs/calicoctl/bgp.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](../images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](../images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # User reference for 'calicoctl bgp' commands
@@ -226,4 +226,4 @@ $ calicoctl bgp default-node-as 64512
 $ calicoctl bgp default-node-as
 64512
 ```
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/calicoctl/bgp.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/calicoctl/bgp.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/calicoctl/checksystem.md
+++ b/docs/calicoctl/checksystem.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](../images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](../images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # User reference for 'calicoctl checksystem' commands
@@ -64,4 +64,4 @@ WARNING: Unable to detect the ipip module. Load with `modprobe ipip`
 $ calicoctl checksystem --libnetwork
 
 ```
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/calicoctl/checksystem.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/calicoctl/checksystem.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/calicoctl/config.md
+++ b/docs/calicoctl/config.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](../images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](../images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # User reference for 'calicoctl config' commands
@@ -206,4 +206,4 @@ $ calicoctl config node bgp loglevel debug
 $ calicoctl config node bgp loglevel --remove
 Value removed
 ```
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/calicoctl/config.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/calicoctl/config.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/calicoctl/container.md
+++ b/docs/calicoctl/container.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](../images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](../images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # User reference for 'calicoctl container' commands
@@ -225,4 +225,4 @@ $ calicoctl container test-container endpoint show
 |  calico  |      docker     | 0d01b3f020fcadfd0090fcbbbbef9658acb26f71c1cb812827afafc625c5ae1a | d79123c4784511e5bd1a080027f532f6 | 192.168.1.4/32 | d6:43:59:f7:93:d3 |          | active |
 +----------+-----------------+------------------------------------------------------------------+----------------------------------+----------------+-------------------+----------+--------+
 ```
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/calicoctl/container.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/calicoctl/container.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/calicoctl/diags.md
+++ b/docs/calicoctl/diags.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](../images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](../images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # User reference for 'calicoctl diags' commands
@@ -80,4 +80,4 @@ such as transfer.sh using curl or similar.  For example:
 
   curl --upload-file /tmp/tmp991ZWu/diags-151015_155032.tar.gz https://transfer.sh/diags-151015_155032.tar.gz
 ```
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/calicoctl/diags.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/calicoctl/diags.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/calicoctl/endpoint.md
+++ b/docs/calicoctl/endpoint.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](../images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](../images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # User reference for 'calicoctl endpoint' commands
@@ -214,4 +214,4 @@ $ calicoctl endpoint d79123c4784511e5bd1a080027f532f6 profile show
 | WEB  |
 +------+
 ```
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/calicoctl/endpoint.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/calicoctl/endpoint.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/calicoctl/ipam.md
+++ b/docs/calicoctl/ipam.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](../images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](../images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # User reference for 'calicoctl ipam' commands
@@ -95,4 +95,4 @@ IP 192.168.1.2 is not currently assigned
 $ calicoctl ipam info 192.168.1.1
 No attributes defined for 192.168.1.1
 ```
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/calicoctl/ipam.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/calicoctl/ipam.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/calicoctl/node.md
+++ b/docs/calicoctl/node.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](../images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](../images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # User reference for 'calicoctl node' commands
@@ -337,4 +337,4 @@ $ calicoctl node bgp peer show --ipv4
 +-----------------------------+--------+
 
 ```
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/calicoctl/node.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/calicoctl/node.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/calicoctl/pool.md
+++ b/docs/calicoctl/pool.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](../images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](../images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # User reference for 'calicoctl pool' commands
@@ -172,4 +172,4 @@ $ calicoctl pool show
 | fd80:24e2:f998:72d6::/64 |         |
 +--------------------------+---------+
 ```
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/calicoctl/pool.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/calicoctl/pool.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/calicoctl/profile.md
+++ b/docs/calicoctl/profile.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](../images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](../images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # User reference for 'calicoctl profile' commands
@@ -544,4 +544,4 @@ Inbound rules:
 Outbound rules:
    1 allow
 ```
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/calicoctl/profile.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/calicoctl/profile.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/calicoctl/status.md
+++ b/docs/calicoctl/status.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](../images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](../images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # User reference for 'calicoctl status' commands
@@ -73,4 +73,4 @@ IPv6 BGP status
 No IPv6 address configured.
 
 ```
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/calicoctl/status.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/calicoctl/status.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/calicoctl/version.md
+++ b/docs/calicoctl/version.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](../images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](../images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # User reference for 'calicoctl version' commands
@@ -52,4 +52,4 @@ Examples:
 $ calicoctl version
 0.8.0
 ```
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/calicoctl/version.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/calicoctl/version.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/etcdStructure.md
+++ b/docs/etcdStructure.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # etcd Directory Structure
@@ -294,4 +294,4 @@ In all cases, the data is a JSON blob in the form:
       "as_num": "The AS Number of the peer"
     }
 
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/etcdStructure.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/etcdStructure.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/images/hosts-on-layer-2-network.svg
+++ b/docs/images/hosts-on-layer-2-network.svg
@@ -16,7 +16,7 @@
    version="1.1"
    inkscape:version="0.91 r13725"
    sodipodi:docname="hosts-on-layer-2-network.svg"
-   inkscape:export-filename="C:\Users\SJC\Documents\Projects\calico-docker docs\hosts-on-layer-2-network.png"
+   inkscape:export-filename="C:\Users\SJC\Documents\Projects\calico-containers docs\hosts-on-layer-2-network.png"
    inkscape:export-xdpi="46.799999"
    inkscape:export-ydpi="46.799999">
   <defs

--- a/docs/kubernetes/AWSIntegration.md
+++ b/docs/kubernetes/AWSIntegration.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](../images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](../images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # Integration with an AWS Kubernetes cluster
@@ -103,7 +103,7 @@ sudo systemctl restart kubelet
 
 ### Node connectivity workaround
 
-As a temporary workaround to issue [projectcalico/calico-docker#426](https://github.com/projectcalico/calico-docker/issues/426), the following manual steps must be run on each node:
+As a temporary workaround to issue [projectcalico/calico-containers#426](https://github.com/projectcalico/calico-containers/issues/426), the following manual steps must be run on each node:
 
 ```
 mkdir -p /etc/iproute2
@@ -140,4 +140,4 @@ Create the pod with `kubectl create -f busybox.yaml`
 And check its Calico endpoint with `ETCD_AUTHORITY=<MASTER_IPV4>:6666 calicoctl endpoint show --detailed`.  You should see that both an IP address and a profile have been assigned to the pod.
 
 For more information on programming Calico Policy in Kubernetes, see our [Kubernetes Policy docs](KubernetesPolicy.md).
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/kubernetes/AWSIntegration.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/kubernetes/AWSIntegration.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/kubernetes/KubernetesIntegration.md
+++ b/docs/kubernetes/KubernetesIntegration.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](../images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](../images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # Add Calico to an Existing Kubernetes Cluster 
@@ -25,7 +25,7 @@ There are two components of a Calico / Kubernetes integration.
 The `calico/node` docker container must be run on the Kubernetes master and each Kubernetes node in your cluster, as it contains the BGP agent necessary for Calico routing to occur.
 The `calico-kubernetes` plugin integrates directly with the Kubernetes `kubelet` process on each node to discover which pods have been created, and adds them to Calico networking.
 
-We recommend using the latest version of [calicoctl](https://github.com/projectcalico/calico-docker/releases/latest) to install both `calico/node` and `calico-kubernetes` on each of your nodes.
+We recommend using the latest version of [calicoctl](https://github.com/projectcalico/calico-containers/releases/latest) to install both `calico/node` and `calico-kubernetes` on each of your nodes.
 
 ## Installing Calico Componenets
 #### 1. Install Calico
@@ -75,4 +75,4 @@ In order to use Calico policy with Kubernetes, the `kube-proxy` component must b
 There are two ways to enable this behavior.
 - Option 1: Start the `kube-proxy` with the `--proxy-mode=iptables` option.
 - Option 2: Annotate the Kubernetes Node API object with `net.experimental.kubernetes.io/proxy-mode` set to `iptables`.
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/kubernetes/KubernetesIntegration.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/kubernetes/KubernetesIntegration.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/kubernetes/KubernetesPolicy.md
+++ b/docs/kubernetes/KubernetesPolicy.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](../images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](../images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # Programming Calico Policy in Kubernetes
@@ -74,4 +74,4 @@ production_pod1
 production_role_backend
 production_version_v1.2.3
 ```
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/kubernetes/KubernetesPolicy.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/kubernetes/KubernetesPolicy.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/kubernetes/PluginConfiguration.md
+++ b/docs/kubernetes/PluginConfiguration.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](../images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](../images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # Configuring the Calico Kubernetes Plugin
@@ -57,4 +57,4 @@ DEFAULT_POLICY=ns_isolation
 CALICO_IPAM=true
 KUBE_AUTH_TOKEN=<INSERT_AUTH_TOKEN>
 ```
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/kubernetes/PluginConfiguration.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/kubernetes/PluginConfiguration.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/kubernetes/README.md
+++ b/docs/kubernetes/README.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](../images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](../images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # Kubernetes with Calico networking
@@ -19,4 +19,4 @@ To build a new Kubernetes cluster with Calico networking, try one of the followi
 - [AWS Cluster Integration](AWSIntegration.md)
 - [DigitalOcean + Fedora](https://github.com/kubernetes/kubernetes/blob/master/docs/getting-started-guides/fedora/fedora-calico.md)
 
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/kubernetes/README.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/kubernetes/README.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/kubernetes/VagrantProvisioner.md
+++ b/docs/kubernetes/VagrantProvisioner.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](../images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](../images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # Running the Kubernetes Vagrant provider with Calico networking
@@ -31,4 +31,4 @@ This will create a 2-node, 1-master cluster, with Calico providing network conne
 The cluster will operate as normal; from the perspective of a Pod's containers, IP connectivity is the same.
 
 The calicoctl tool has been installed at /home/vagrant/calicoctl, so this can be used as normal to assist debugging. Note that Calico policy can be configured using calicoctl, but it is not fully supported in the Kubernetes environment; pod-to-pod policy can be enforced, but traffic to Kubernetes Services will not hit the correct policy rules. We are actively working on enhancing Kubernetes to support Calico policy with services.
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/kubernetes/VagrantProvisioner.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/kubernetes/VagrantProvisioner.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # Logging
@@ -98,4 +98,4 @@ container.  e.g.
 
 For details on how to change the log levels for the plugin, please view the
 [libnetwork-plugin documentation](https://github.com/projectcalico/libnetwork-plugin/blob/master/README.md).
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/logging.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/logging.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/mesos/DockerizedDeployment.md
+++ b/docs/mesos/DockerizedDeployment.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](../images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](../images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # Deploying a Dockerized Mesos Cluster with Calico.
@@ -162,7 +162,7 @@ Next, download the unit files
 
 `calicoctl` is a small CLI tool to control your Calico network.  It's used to start Calico services on your compute host, as well as inspect and modify Calico configuration.
 
-    curl -L -O https://github.com/projectcalico/calico-docker/releases/download/v0.8.0/calicoctl
+    curl -L -O https://github.com/projectcalico/calico-containers/releases/download/v0.8.0/calicoctl
     chmod +x calicoctl
     sudo cp calicoctl /usr/bin/
 
@@ -217,4 +217,4 @@ At time of writing Marathon still uses the old Mesos networking, rather than Cal
 [mesos]: https://mesos.apache.org/
 [net-modules]: https://github.com/mesosphere/net-modules
 [docker]: https://www.docker.com/
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/mesos/DockerizedDeployment.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/mesos/DockerizedDeployment.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/mesos/ManualInstallCalicoMesos.md
+++ b/docs/mesos/ManualInstallCalicoMesos.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](../images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](../images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # Manually Install Calico and Mesos on Agent
@@ -101,7 +101,7 @@ The last Calico component required for Calico networking in Mesos is `calico-nod
 
 ```
 sudo yum install -y wget
-wget https://github.com/projectcalico/calico-docker/releases/download/v0.9.0/calicoctl
+wget https://github.com/projectcalico/calico-containers/releases/download/v0.9.0/calicoctl
 chmod +x calicoctl
 sudo ETCD_AUTHORITY=<IP of host with etcd>:4001 ./calicoctl node
 ```
@@ -186,4 +186,4 @@ We provide the `ETCD_AUTHORITY` environment variable here to allow the  `calico_
 ## 9. Launch Tasks
 With your cluster up and running, you can now [Launch Tasks with Calico Networking using Marathon](README.md#3-launching-tasks).
 
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/mesos/ManualInstallCalicoMesos.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/mesos/ManualInstallCalicoMesos.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/mesos/MesosClusterPreparation.md
+++ b/docs/mesos/MesosClusterPreparation.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](../images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](../images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # Mesos Cluster and Master Preparation
@@ -128,4 +128,4 @@ sudo systemctl restart firewalld
 # Next Steps 
 With your Master configured, you're ready to [Install Calico](README.md#2-install-mesos-slave-netmodules-and-calico).
 
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/mesos/MesosClusterPreparation.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/mesos/MesosClusterPreparation.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/mesos/README.md
+++ b/docs/mesos/README.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](../images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](../images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # Mesos with Calico Networking
@@ -106,4 +106,4 @@ curl -X PUT -H "Content-Type: application/json" http://localhost:8080/v2/groups/
 [net-modules]: https://github.com/mesosphere/net-modules
 [docker]: https://www.docker.com/
 [marathon-ip-per-task-doc]: https://github.com/mesosphere/marathon/blob/v0.14.0-RC1/docs/docs/ip-per-task.md
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/mesos/README.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/mesos/README.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/mesos/RpmInstallCalicoMesos.md
+++ b/docs/mesos/RpmInstallCalicoMesos.md
@@ -1,9 +1,9 @@
 <!--- master only -->
-> ![warning](../images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+> ![warning](../images/warning.png) This document applies to the HEAD of the calico-containers source tree.
 >
-> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-docker/blob/v0.14.0/README.md).
+> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.14.0/README.md).
 <!--- else
-> You are viewing the calico-docker documentation for release **release**.
+> You are viewing the calico-containers documentation for release **release**.
 <!--- end of master only -->
 
 # RPM Install Calico + Mesos
@@ -63,4 +63,4 @@ sudo systemctl status mesos-slave.service
 
 [calico-mesos]: https://github.com/projectcalico/calico-mesos/releases/latest
 
-[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/docs/mesos/RpmInstallCalicoMesos.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/mesos/RpmInstallCalicoMesos.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/release-scripts/do_release.py
+++ b/release-scripts/do_release.py
@@ -81,7 +81,7 @@ CANDIDATE_VERSION_REPLACE = [
 # point to the Git archives.
 FINAL_VERSION_REPLACE = [
     (re.compile('http://www\.projectcalico\.org/builds/calicoctl\?circleci\-branch=.*\-candidate'),
-     'https://github.com/projectcalico/calico-docker/releases/download/{version}/calicoctl'),
+     'https://github.com/projectcalico/calico-containers/releases/download/{version}/calicoctl'),
 ]
 
 
@@ -104,7 +104,7 @@ MASTER_VERSION_REPLACE = [
      '__kubernetes_plugin_version__ = "{kubernetes-version}"'),
 
     (re.compile(r'https://github\.com/projectcalico/calico\-docker/blob/.*/README\.md'),
-     'https://github.com/projectcalico/calico-docker/blob/{version}/README.md')
+     'https://github.com/projectcalico/calico-containers/blob/{version}/README.md')
 ]
 
 
@@ -147,7 +147,7 @@ def start_release():
 
 
     if not (calico_version and libcalico_version and libnetwork_version and kubernetes_version):
-        para("To pin the calico libraries used by calico-docker, please specify "
+        para("To pin the calico libraries used by calico-containers, please specify "
              "the name of the requested versions as they appear in the GitHub "
              "releases.")
 
@@ -209,7 +209,7 @@ def start_release():
     bullet("CoreOS default networking", level=1)
     para("Follow the URL below to view the correct demonstration instructions "
          "for this release candidate.")
-    bullet("https://github.com/projectcalico/calico-docker/tree/%s-candidate" % new_version)
+    bullet("https://github.com/projectcalico/calico-containers/tree/%s-candidate" % new_version)
     next("Once you have completed the testing, re-run the script.")
 
 

--- a/release-scripts/utils.py
+++ b/release-scripts/utils.py
@@ -24,7 +24,7 @@ PATH_DOCS = "docs"
 PATH_RELEASE_DATA = ".releasedata"
 PATH_BUILDING = path.join(PATH_DOCS, "Building.md")
 
-# Regexes for calico-docker version format.
+# Regexes for calico-containers version format.
 INIT_VERSION = re.compile(r'__version__\s*=\s*"(.*)"')
 VERSION_RE = re.compile(r'^v(\d+)\.(\d+)\.(\d+)$')
 VERSION_NAME_RE = re.compile(r'^v(\d+)\.(\d+)\.(\d+)[.-](\w+)$')
@@ -429,20 +429,20 @@ def validate_uri(filename, uri):
         if uri.startswith("https://img.shields.io"):
             return True
 
-        # There should no calico-docker URL except for:
+        # There should no calico-containers URL except for:
         # - The README URLs which we skip since these are auto-generated
         # - Issues (which we can validate)
         # - Releases (which we can validate)
         # Everything else should be specified with a relative path.
-        if (uri.startswith("https://github.com/projectcalico/calico-docker") or
-            uri.startswith("https://www.github.com/projectcalico/calico-docker")):
+        if (uri.startswith("https://github.com/projectcalico/calico-containers") or
+            uri.startswith("https://www.github.com/projectcalico/calico-containers")):
 
             if README_RE.match(uri):
                 return True
 
-            if ((uri.find("/calico-docker/issues") < 0) and
-                (uri.find("/calico-docker/releases") < 0)):
-                print_bullet("%s: Do not specify calico-docker file using a URL, "
+            if ((uri.find("/calico-containers/issues") < 0) and
+                (uri.find("/calico-containers/releases") < 0)):
+                print_bullet("%s: Do not specify calico-containers file using a URL, "
                              "specify using a relative path: %s" % (filename, uri))
                 return False
 
@@ -474,7 +474,7 @@ def validate_analytics_url(filename, analytics_url):
     :param url:  The analytics URL to validate.
     :return:  True if URL is valid and accessible
     """
-    expected_url = "https://ga-beacon.appspot.com/UA-52125893-3/calico-docker/%s?pixel" % filename
+    expected_url = "https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/%s?pixel" % filename
     if analytics_url != expected_url:
         print_bullet("%s: Anayltics URL is incorrect, should be %s" % (filename, expected_url))
         return False


### PR DESCRIPTION
Tom - rename of calico-docker to calico-containers.

Search and replace with some fix up.

