### PR TITLE
Remove the --kubernetes and --rkt commands

### DIFF
--- a/calicoctl/calico_ctl/__init__.py
+++ b/calicoctl/calico_ctl/__init__.py
@@ -1,6 +1,4 @@
 __version__ = "0.14.0-dev"
-__kubernetes_plugin_version__ = "v0.7.0"
-__rkt_plugin_version__ = "v0.1.0"
 __libnetwork_plugin_version__ = "v0.7.0-dev"
 __libcalico_version__ = "v0.9.0-dev"
 __felix_version__ = "1.3.0a6-dev"

--- a/calicoctl/calico_ctl/node.py
+++ b/calicoctl/calico_ctl/node.py
@@ -24,7 +24,6 @@ from subprocess32 import call
 from netaddr import IPAddress, AddrFormatError
 from prettytable import PrettyTable
 
-from . import __rkt_plugin_version__, __kubernetes_plugin_version__
 from pycalico.datastore_datatypes import IPPool
 from pycalico.datastore_datatypes import BGPPeer
 from pycalico.datastore import (ETCD_AUTHORITY_ENV, ETCD_AUTHORITY_DEFAULT,
@@ -48,8 +47,7 @@ __doc__ = """
 Usage:
   calicoctl node [--ip=<IP>] [--ip6=<IP6>] [--node-image=<DOCKER_IMAGE_NAME>]
     [--runtime=<RUNTIME>] [--as=<AS_NUM>] [--log-dir=<LOG_DIR>]
-    [--detach=<DETACH>] [--rkt]
-    [(--kubernetes [--kube-plugin-version=<KUBE_PLUGIN_VERSION])]
+    [--detach=<DETACH>]
     [(--libnetwork [--libnetwork-image=<LIBNETWORK_IMAGE_NAME>])]
   calicoctl node stop [--force]
   calicoctl node remove [--remove-endpoints]
@@ -83,31 +81,17 @@ Options:
   --as=<AS_NUM>             The default AS number for this node.
   --ipv4                    Show IPv4 information only.
   --ipv6                    Show IPv6 information only.
-  --kubernetes              Download and install the Kubernetes plugin.
-  --kube-plugin-version=<KUBE_PLUGIN_VERSION> Version of the Kubernetes plugin
-                            to install when using the --kubernetes option.
-                            [default: %s]
-  --rkt                     Download and install the rkt plugin.
   --libnetwork              Use the libnetwork plugin.
   --libnetwork-image=<LIBNETWORK_IMAGE_NAME>    Docker image to use for
                             Calico's libnetwork driver.
                             [default: calico/node-libnetwork:latest]
-""" % __kubernetes_plugin_version__
+"""
 
 DEFAULT_IPV4_POOL = IPPool("192.168.0.0/16")
 DEFAULT_IPV6_POOL = IPPool("fd80:24e2:f998:72d6::/64")
 
 CALICO_NETWORKING_ENV = "CALICO_NETWORKING"
 CALICO_NETWORKING_DEFAULT = "true"
-
-KUBERNETES_BINARY_URL = 'https://github.com/projectcalico/calico-kubernetes/releases/download/%s/calico_kubernetes'
-KUBERNETES_PLUGIN_DIR = '/usr/libexec/kubernetes/kubelet-plugins/net/exec/calico/'
-KUBERNETES_PLUGIN_DIR_BACKUP = '/etc/kubelet-plugins/calico/'
-
-RKT_PLUGIN_VERSION = __rkt_plugin_version__
-RKT_BINARY_URL = 'https://github.com/projectcalico/calico-rkt/releases/download/%s/calico_rkt' % RKT_PLUGIN_VERSION
-RKT_PLUGIN_DIR = '/usr/lib/rkt/plugins/net/'
-RKT_PLUGIN_DIR_BACKUP = '/etc/rkt-plugins/calico/'
 
 ETCD_KEY_NODE_FILE = "/etc/calico/certs/key.pem"
 ETCD_CERT_NODE_FILE = "/etc/calico/certs/cert.crt"
@@ -211,8 +195,6 @@ def node(arguments):
         assert arguments.get("--detach") in ["true", "false"]
         detach = arguments.get("--detach") == "true"
 
-        kubernetes_version = None if not arguments.get("--kubernetes") \
-                                else arguments.get("--kube-plugin-version")
         libnetwork_image = None if not arguments.get("--libnetwork") \
                                 else arguments.get("--libnetwork-image")
         node_start(ip=arguments.get("--ip"),
@@ -222,13 +204,11 @@ def node(arguments):
                    ip6=arguments.get("--ip6"),
                    as_num=as_num,
                    detach=detach,
-                   kubernetes_version=kubernetes_version,
-                   rkt=arguments.get("--rkt"),
                    libnetwork_image=libnetwork_image)
 
 
 def node_start(node_image, runtime, log_dir, ip, ip6, as_num, detach,
-               kubernetes_version, rkt, libnetwork_image):
+               libnetwork_image):
     """
     Create the calico-node container and establish Calico networking on this
     host.
@@ -240,9 +220,6 @@ def node_start(node_image, runtime, log_dir, ip, ip6, as_num, detach,
     the global default value will be used.
     :param detach: True to run in Docker's "detached" mode, False to run
     attached.
-    :param kubernetes_version: The version of the calico-kubernetes plugin to
-     install, or None if the plugin should not be installed.
-    :param rkt: True to install the rkt plugin, False otherwise.
     :param libnetwork_image: The name of the Calico libnetwork driver image to
     use.  None, if not using libnetwork.
     :return:  None.
@@ -296,26 +273,6 @@ def node_start(node_image, runtime, log_dir, ip, ip6, as_num, detach,
 
     # Warn if this hostname conflicts with an existing host
     warn_if_hostname_conflict(ip)
-
-    # Install Kubernetes plugin
-    if kubernetes_version:
-        # Build a URL based on the provided Kubernetes_version.
-        url = KUBERNETES_BINARY_URL % kubernetes_version
-        try:
-            # Attempt to install to the default Kubernetes directory
-            install_plugin(KUBERNETES_PLUGIN_DIR, url)
-        except OSError:
-            # Use the backup directory
-            install_plugin(KUBERNETES_PLUGIN_DIR_BACKUP, url)
-
-    # Install rkt plugin
-    if rkt:
-        try:
-            # Attempt to install to the default rkt directory
-            install_plugin(RKT_PLUGIN_DIR, RKT_BINARY_URL)
-        except OSError:
-            # Use the backup directory
-            install_plugin(RKT_PLUGIN_DIR_BACKUP, RKT_BINARY_URL)
 
     # Set up etcd
     ipv4_pools = client.get_ip_pools(4)
@@ -837,35 +794,6 @@ def _attach_and_stream(container):
         # Could either be this process is being killed, or output generator
         # raises an exception.
         docker_client.stop(container)
-
-
-def install_plugin(plugin_dir, binary_url):
-    """
-    Downloads a plugin to the specified directory.
-    :param plugin_dir: Desired download destination for the plugin.
-    :param binary_url: Download the plugin from this url.
-    :return: Nothing
-    """
-    if not os.path.exists(plugin_dir):
-        os.makedirs(plugin_dir)
-    binary_path = plugin_dir + 'calico'
-    getter = URLGetter()
-    try:
-        getter.retrieve(binary_url, binary_path)
-    except IOError:
-        # We were unable to download the binary.  This may be because the
-        # user provided an invalid calico-kubernetes version.
-        print "ERROR: Couldn't download the plugin from %s" % binary_url
-        sys.exit(1)
-    else:
-        # Download successful - change permissions to allow execution.
-        try:
-            st = os.stat(binary_path)
-            executable_permissions = st.st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
-            os.chmod(binary_path, executable_permissions)
-        except OSError:
-            print "ERROR: Unable to set permissions on plugin %s" % binary_path
-            sys.exit(1)
 
 
 def _ensure_host_tunnel_addr(ipv4_pools, ipip_pools):

--- a/calicoctl/tests/unit/node_test.py
+++ b/calicoctl/tests/unit/node_test.py
@@ -179,7 +179,6 @@ class TestNode(unittest.TestCase):
     @patch('calico_ctl.node.warn_if_unknown_ip', autospec=True)
     @patch('calico_ctl.node.warn_if_hostname_conflict', autospec=True)
     @patch('calico_ctl.node.error_if_bgp_ip_conflict', autospec=True)
-    @patch('calico_ctl.node.install_plugin', autospec=True)
     @patch('calico_ctl.node.client', autospec=True)
     @patch('calico_ctl.node.docker_client', autospec=True)
     @patch('calico_ctl.node.docker', autospec=True)
@@ -187,7 +186,7 @@ class TestNode(unittest.TestCase):
     @patch('calico_ctl.node._attach_and_stream', autospec=True)
     def test_node_dockerless_start(self, m_attach_and_stream,
                                    m_find_or_pull_node_image, m_docker,
-                                   m_docker_client, m_client, m_install_plugin,
+                                   m_docker_client, m_client,
                                    m_error_if_bgp_ip_conflict,
                                    m_warn_if_hostname_conflict,
                                    m_warn_if_unknown_ip, m_get_host_ips,
@@ -215,30 +214,11 @@ class TestNode(unittest.TestCase):
         ip6 = 'aa:bb::zz'
         as_num = ''
         detach = True
-        kube_plugin_version = 'v0.2.1'
-        rkt = True
         libnetwork = False
 
         # Call method under test
         node.node_start(node_image, runtime, log_dir, ip, ip6, as_num, detach,
-                        kube_plugin_version, rkt, libnetwork)
-
-        # Set up variables used in assertion statements
-        environment = [
-            "HOSTNAME=%s" % node.hostname,
-            "IP=%s" % ip_2,
-            "IP6=%s" % ip6,
-            "ETCD_AUTHORITY=%s" % ETCD_AUTHORITY_DEFAULT,  # etcd host:port
-            "FELIX_ETCDADDR=%s" % ETCD_AUTHORITY_DEFAULT,  # etcd host:port
-            "CALICO_NETWORKING=%s" % node.CALICO_NETWORKING_DEFAULT,
-        ]
-        binds = {
-            log_dir:
-                {
-                    "bind": "/var/log/calico",
-                    "ro": False
-                }
-        }
+                        libnetwork)
 
         # Assert
         m_os_path_exists.assert_called_once_with(log_dir)
@@ -260,9 +240,6 @@ class TestNode(unittest.TestCase):
             node.hostname, ip_2, ip6, as_num
         )
 
-        url = node.KUBERNETES_BINARY_URL % kube_plugin_version
-        m_install_plugin.assert_has_calls([call(node.KUBERNETES_PLUGIN_DIR, url),
-                                           call(node.RKT_PLUGIN_DIR, node.RKT_BINARY_URL)])
         self.assertFalse(m_docker_client.remove_container.called)
         self.assertFalse(m_docker.utils.create_host_config.called)
         self.assertFalse(m_find_or_pull_node_image.called)
@@ -280,7 +257,6 @@ class TestNode(unittest.TestCase):
     @patch('calico_ctl.node.warn_if_unknown_ip', autospec=True)
     @patch('calico_ctl.node.warn_if_hostname_conflict', autospec=True)
     @patch('calico_ctl.node.error_if_bgp_ip_conflict', autospec=True)
-    @patch('calico_ctl.node.install_plugin', autospec=True)
     @patch('calico_ctl.node.client', autospec=True)
     @patch('calico_ctl.node.docker_client', autospec=True)
     @patch('calico_ctl.node.docker', autospec=True)
@@ -288,7 +264,7 @@ class TestNode(unittest.TestCase):
     @patch('calico_ctl.node._attach_and_stream', autospec=True)
     def test_node_start(self, m_attach_and_stream,
                         m_find_or_pull_node_image, m_docker,
-                        m_docker_client, m_client, m_install_plugin,
+                        m_docker_client, m_client,
                         m_error_if_bgp_ip_conflict, m_warn_if_hostname_conflict,
                         m_warn_if_unknown_ip, m_get_host_ips, m_setup_ip,
                         m_check_system, m_ensure_host_tunnel_addr,
@@ -320,13 +296,11 @@ class TestNode(unittest.TestCase):
         ip6 = 'aa:bb::zz'
         as_num = ''
         detach = False
-        kube_plugin_version = 'v0.2.1'
-        rkt = True
         libnetwork = False
 
         # Call method under test
         node.node_start(node_image, runtime, log_dir, ip, ip6, as_num, detach,
-                        kube_plugin_version, rkt, libnetwork)
+                        libnetwork)
 
         # Set up variables used in assertion statements
         environment = [
@@ -370,9 +344,6 @@ class TestNode(unittest.TestCase):
                                                           ipip_pools)
         assert_false(m_remove_host_tunnel_addr.called)
 
-        url = node.KUBERNETES_BINARY_URL % kube_plugin_version
-        m_install_plugin.assert_has_calls([call(node.KUBERNETES_PLUGIN_DIR, url),
-                                           call(node.RKT_PLUGIN_DIR, node.RKT_BINARY_URL)])
         m_docker_client.remove_container.assert_called_once_with(
             'calico-node', force=True
         )
@@ -405,7 +376,6 @@ class TestNode(unittest.TestCase):
     @patch('calico_ctl.node.warn_if_unknown_ip', autospec=True)
     @patch('calico_ctl.node.warn_if_hostname_conflict', autospec=True)
     @patch('calico_ctl.node.error_if_bgp_ip_conflict', autospec=True)
-    @patch('calico_ctl.node.install_plugin', autospec=True)
     @patch('calico_ctl.node.client', autospec=True)
     @patch('calico_ctl.node.docker_client', autospec=True)
     @patch('calico_ctl.node.docker', autospec=True)
@@ -413,7 +383,7 @@ class TestNode(unittest.TestCase):
     @patch('calico_ctl.node._attach_and_stream', autospec=True)
     def test_node_start_secure(self, m_attach_and_stream,
                                m_find_or_pull_node_image, m_docker,
-                               m_docker_client, m_client, m_install_plugin,
+                               m_docker_client, m_client,
                                m_error_if_bgp_ip_conflict,
                                m_warn_if_hostname_conflict, m_warn_if_unknown_ip,
                                m_get_host_ips, m_setup_ip, m_check_system,
@@ -459,13 +429,11 @@ class TestNode(unittest.TestCase):
         ip6 = 'aa:bb::zz'
         as_num = ''
         detach = False
-        kube_plugin_version = 'v0.6.0'
-        rkt = True
         libnetwork_image = 'libnetwork_image'
 
         # Call method under test
         node.node_start(node_image, runtime, log_dir, ip, ip6, as_num, detach,
-                        kube_plugin_version, rkt, libnetwork_image)
+                        libnetwork_image)
 
         # Set up variables used in assertion statements
         environment_node = [
@@ -528,11 +496,6 @@ class TestNode(unittest.TestCase):
                                                      as_num)
         assert_true(m_remove_host_tunnel_addr.called)
 
-        url = node.KUBERNETES_BINARY_URL % kube_plugin_version
-        m_install_plugin.assert_has_calls([
-            call(node.KUBERNETES_PLUGIN_DIR, url),
-            call(node.RKT_PLUGIN_DIR, node.RKT_BINARY_URL)
-        ])
         m_docker_client.remove_container.assert_has_calls([
             call('calico-node', force=True),
             call('calico-libnetwork', force=True)
@@ -567,51 +530,6 @@ class TestNode(unittest.TestCase):
                                                 call(container2)])
         m_attach_and_stream.assert_called_once_with(container1)
 
-    @patch('os.path.exists', autospec=True)
-    @patch('os.makedirs', autospec=True)
-    @patch('calico_ctl.node.check_system', autospec=True)
-    @patch('calico_ctl.node._setup_ip_forwarding', autospec=True)
-    @patch('calico_ctl.node.get_host_ips', autospec=True)
-    @patch('calico_ctl.node.warn_if_unknown_ip', autospec=True)
-    @patch('calico_ctl.node.warn_if_hostname_conflict', autospec=True)
-    @patch('calico_ctl.node.error_if_bgp_ip_conflict', autospec=True)
-    @patch('calico_ctl.node.install_plugin', autospec=True)
-    def test_node_start_call_backup_kube_directory(
-            self, m_install_plugin, m_warn_if_hostname_conflict,
-            m_error_if_bgp_ip_conflict, m_warn_if_unknown_ip, m_get_host_ips,
-            m_setup_ip, m_check_system, m_os_makedirs, m_os_path_exists):
-        """
-        Test that node_start calls the backup kuberentes plugin directory
-        when install_kubernetes cannot access the default kubernetes directory
-        """
-        # Set up mock objects
-        m_os_path_exists.return_value = True
-        m_get_host_ips.return_value = ['1.1.1.1']
-        m_install_plugin.side_effect = OSError
-        m_check_system.return_value = [True, True, True]
-
-        # Set up arguments
-        node_image = "node_image"
-        runtime = 'docker'
-        log_dir = './log_dir'
-        ip = ''
-        ip6 = 'aa:bb::zz'
-        as_num = ''
-        detach = False
-        kube_plugin_version = 'v0.2.1'
-        rkt = False
-        libnetwork = False
-
-        # Test expecting OSError exception
-        self.assertRaises(OSError, node.node_start,
-                          node_image, runtime, log_dir, ip, ip6, as_num, detach,
-                          kube_plugin_version, rkt, libnetwork)
-
-        url = node.KUBERNETES_BINARY_URL % kube_plugin_version
-        m_install_plugin.assert_has_calls([
-            call(node.KUBERNETES_PLUGIN_DIR, url),
-            call(node.KUBERNETES_PLUGIN_DIR_BACKUP, url)
-        ])
 
     @patch('os.path.exists', autospec=True)
     @patch('os.makedirs', autospec=True)
@@ -621,55 +539,10 @@ class TestNode(unittest.TestCase):
     @patch('calico_ctl.node.warn_if_unknown_ip', autospec=True)
     @patch('calico_ctl.node.warn_if_hostname_conflict', autospec=True)
     @patch('calico_ctl.node.error_if_bgp_ip_conflict', autospec=True)
-    @patch('calico_ctl.node.install_plugin', autospec=True)
-    def test_node_start_call_backup_rkt_directory(
-            self, m_install_plugin, m_error_if_bgp_ip_conflict,
-            m_warn_if_hostname_conflict, m_warn_if_unknown_ip, m_get_host_ips,
-            m_setup_ip, m_check_system, m_os_makedirs, m_os_path_exists):
-        """
-        Test that node_start calls the backup kuberentes plugin directory
-        when install_kubernetes cannot access the default kubernetes directory
-        """
-        # Set up mock objects
-        m_os_path_exists.return_value = True
-        m_get_host_ips.return_value = ['1.1.1.1']
-        m_install_plugin.side_effect = OSError
-        m_check_system.return_value = [True, True, True]
-
-        # Set up arguments
-        node_image = "node_image"
-        runtime = 'docker'
-        log_dir = './log_dir'
-        ip = ''
-        ip6 = 'aa:bb::zz'
-        as_num = ''
-        detach = False
-        kube_plugin_version = None
-        rkt = True
-        libnetwork = False
-
-        # Test expecting OSError exception
-        self.assertRaises(OSError, node.node_start,
-                          node_image, runtime, log_dir, ip, ip6, as_num, detach,
-                          kube_plugin_version, rkt, libnetwork)
-        m_install_plugin.assert_has_calls([
-            call(node.RKT_PLUGIN_DIR, node.RKT_BINARY_URL),
-            call(node.RKT_PLUGIN_DIR_BACKUP, node.RKT_BINARY_URL)
-        ])
-
-    @patch('os.path.exists', autospec=True)
-    @patch('os.makedirs', autospec=True)
-    @patch('calico_ctl.node.check_system', autospec=True)
-    @patch('calico_ctl.node._setup_ip_forwarding', autospec=True)
-    @patch('calico_ctl.node.get_host_ips', autospec=True)
-    @patch('calico_ctl.node.warn_if_unknown_ip', autospec=True)
-    @patch('calico_ctl.node.warn_if_hostname_conflict', autospec=True)
-    @patch('calico_ctl.node.error_if_bgp_ip_conflict', autospec=True)
-    @patch('calico_ctl.node.install_plugin', autospec=True)
     @patch('calico_ctl.node.client', autospec=True)
     @patch('calico_ctl.node.docker_client', autospec=True)
     def test_node_start_remove_container_error(
-            self, m_docker_client, m_client, m_install_plugin,
+            self, m_docker_client, m_client,
             m_error_if_bgp_ip_conflict, m_warn_if_hostname_conflict,
             m_warn_if_unknown_ip, m_get_host_ips, m_setup_ip, m_check_system,
             m_os_makedirs, m_os_path_exists):
@@ -690,14 +563,12 @@ class TestNode(unittest.TestCase):
         ip6 = 'aa:bb::zz'
         as_num = ''
         detach = False
-        kube_plugin_version = 'v0.2.1'
-        rkt = False
         libnetwork = False
 
         # Testing expecting APIError exception
         self.assertRaises(APIError, node.node_start,
                           node_image, runtime, log_dir, ip, ip6, as_num, detach,
-                          kube_plugin_version, rkt, libnetwork)
+                          libnetwork)
 
     @patch('sys.exit', autospec=True)
     @patch('os.path.exists', autospec=True)
@@ -708,11 +579,10 @@ class TestNode(unittest.TestCase):
     @patch('calico_ctl.node.warn_if_unknown_ip', autospec=True)
     @patch('calico_ctl.node.warn_if_hostname_conflict', autospec=True)
     @patch('calico_ctl.node.error_if_bgp_ip_conflict', autospec=True)
-    @patch('calico_ctl.node.install_plugin', autospec=True)
     @patch('calico_ctl.node.client', autospec=True)
     @patch('calico_ctl.node.docker_client', autospec=True)
     def test_node_start_no_detected_ips(
-            self, m_docker_client, m_client, m_install_plugin,
+            self, m_docker_client, m_client,
             m_error_if_bgp_ip_conflict, m_warn_if_hostname_conflict,
             m_warn_if_unknown_ip, m_get_host_ips, m_setup_ip, m_check_system,
             m_os_makedirs, m_os_path_exists, m_sys_exit):
@@ -732,13 +602,11 @@ class TestNode(unittest.TestCase):
         ip6 = 'aa:bb::zz'
         as_num = ''
         detach = False
-        kube_plugin_version = 'v0.2.1'
-        rkt = False
         libnetwork = False
 
         # Call method under test
         node.node_start(node_image, runtime, log_dir, ip, ip6, as_num, detach,
-                        kube_plugin_version, rkt, libnetwork)
+                        libnetwork)
 
         # Assert
         m_sys_exit.assert_called_once_with(1)
@@ -751,11 +619,10 @@ class TestNode(unittest.TestCase):
     @patch('calico_ctl.node.warn_if_unknown_ip', autospec=True)
     @patch('calico_ctl.node.warn_if_hostname_conflict', autospec=True)
     @patch('calico_ctl.node.error_if_bgp_ip_conflict', autospec=True)
-    @patch('calico_ctl.node.install_plugin', autospec=True)
     @patch('calico_ctl.node.client', autospec=True)
     @patch('calico_ctl.node.docker_client', autospec=True)
     def test_node_start_create_default_ip_pools(
-            self, m_docker_client, m_client, m_install_plugin,
+            self, m_docker_client, m_client,
             m_error_if_bgp_ip_conflict, m_warn_if_hostname_conflict,
             m_warn_if_unknown_ip, m_get_host_ips, m_setup_ip, m_check_system,
             m_os_makedirs, m_os_path_exists):
@@ -775,13 +642,11 @@ class TestNode(unittest.TestCase):
         ip6 = 'aa:bb::zz'
         as_num = ''
         detach = False
-        kube_plugin_version = 'v0.2.1'
-        rkt = False
         libnetwork = False
 
         # Call method under test
         node.node_start(node_image, runtime, log_dir, ip, ip6, as_num, detach,
-                        kube_plugin_version, rkt, libnetwork)
+                        libnetwork)
 
         # Assert
         m_client.add_ip_pool.assert_has_calls([
@@ -926,20 +791,6 @@ class TestNode(unittest.TestCase):
             m_docker_client.inspect_container.return_value = {"State": {"Running": test}}
             self.assertEquals(node._container_running("container1"), test)
 
-    @patch("calico_ctl.node.URLGetter", autospec=True)
-    @patch("calico_ctl.node.os", autospec=True)
-    def test_install_plugin(self, m_os, m_url_getter):
-        """
-        Test installation of Kubernetes plugin
-        """
-        url = "http://somefake/url"
-        path = "/path/to/downloaded/binary/"
-
-        # Run method
-        node.install_plugin(path, url)
-
-        # Assert the file URL was downloaded.
-        m_url_getter().retrieve.assert_called_once_with(url, path + "calico")
 
     @patch("calico_ctl.node.client", autospec=True)
     @patch("sys.exit", autospec=True)

--- a/docs/RepoStructure.md
+++ b/docs/RepoStructure.md
@@ -64,21 +64,14 @@ There are several integrations available for Calico in a containerized
 environment.  The repositories below hold the plugin code for these 
 integrations.
 
- - [calico-kubernetes](https://github.com/projectcalico/calico-kubernetes): 
-   Implements the Calico plugin for running Calico with the 
-   [kubernetes](https://github.com/kubernetes/kubernetes) orchestrator. This is 
-   used when the Calico node is started with the `--kubernetes` flag, and
-   installed as a binary downloaded from a particular release.
-
- - [calico-mesos](https://github.com/projectcalico/calico-mesos): Implements 
+ - [calico-mesos](https://github.com/projectcalico/calico-mesos): Implements
    the Calico plugin for running Calico with the [mesos](https://github.com/apache/mesos) 
    orchestrator.  This plugin may be installed manually (from a binary attached
    to a relase), or as an RPM which can be created.
 
- - [calico-rkt](https://github.com/projectcalico/calico-rkt): Implements the 
-   Calico plugin for running Calico with the [rkt](https://github.com/coreos/rkt) 
-   orchestrator. This is used when the Calico node is started with the `--rkt` 
-   flag, and installed as a binary downloaded from a particular release.
+ - [calico-cni](https://github.com/projectcalico/calico-cni): Implements the
+   Calico plugin for running Calico with [rkt](https://github.com/coreos/rkt)
+   or the [kubernetes](https://github.com/kubernetes/kubernetes) orchestrator.
 
  - [libnetwork-plugin](https://github.com/projectcalico/libnetwork-plugin): 
    Implements Calico plugin support for the (libnetwork based) Docker 

--- a/docs/calicoctl/node.md
+++ b/docs/calicoctl/node.md
@@ -33,8 +33,7 @@ calicoctl node commands.
 Usage:
   calicoctl node [--ip=<IP>] [--ip6=<IP6>] [--node-image=<DOCKER_IMAGE_NAME>]
     [--runtime=<RUNTIME>] [--as=<AS_NUM>] [--log-dir=<LOG_DIR>]
-    [--detach=<DETACH>] [--rkt]
-    [(--kubernetes [--kube-plugin-version=<KUBE_PLUGIN_VERSION])]
+    [--detach=<DETACH>]
     [(--libnetwork [--libnetwork-image=<LIBNETWORK_IMAGE_NAME>])]
   calicoctl node stop [--force]
   calicoctl node remove [--remove-endpoints]
@@ -68,11 +67,6 @@ Options:
   --as=<AS_NUM>             The default AS number for this node.
   --ipv4                    Show IPv4 information only.
   --ipv6                    Show IPv6 information only.
-  --kubernetes              Download and install the Kubernetes plugin.
-  --kube-plugin-version=<KUBE_PLUGIN_VERSION> Version of the Kubernetes plugin
-                            to install when using the --kubernetes option.
-                            [default: v0.3.0]
-  --rkt                     Download and install the rkt plugin.
   --libnetwork              Use the libnetwork plugin.
   --libnetwork-image=<LIBNETWORK_IMAGE_NAME>    Docker image to use for
                             Calico's libnetwork driver.
@@ -105,8 +99,7 @@ Command syntax:
 ```
 calicoctl node [--ip=<IP>] [--ip6=<IP6>] [--node-image=<DOCKER_IMAGE_NAME>] 
     [--runtime=<RUNTIME>] [--as=<AS_NUM>] [--log-dir=<LOG_DIR>]
-    [--detach=<DETACH>] [--rkt]
-    [(--kubernetes [--kube-plugin-version=<KUBE_PLUGIN_VERSION])]
+    [--detach=<DETACH>]
     [(--libnetwork [--libnetwork-image=<LIBNETWORK_IMAGE_NAME>])]
 
     <IP>: Unique IPv4 address associated with an interface on the host machine.
@@ -124,8 +117,6 @@ calicoctl node [--ip=<IP>] [--ip6=<IP6>] [--node-image=<DOCKER_IMAGE_NAME>]
     <LIBNETWORK_IMAGE_NAME>: Desired calico/node-libnetwork Docker image to use when 
                              using the Docker libnetwork driver.
 
-    --kubernetes: Download and install the kubernetes plugin.
-    --rkt: Download and install the rkt plugin.
     --libnetwork: Download and run the calico/node-libnetwork Docker image.
 ```
 
@@ -142,12 +133,6 @@ The `--ip` and `--ip6` flags should be used to specify a unique IP address that
 is owned by an interface on this Calico host system.  These IP addresses are 
 used to identify source addresses for BGP peering, allowing an interface 
 through the host system over which traffic will flow to the workloads.
-
-The `--kubernetes` flag configures your Calico node with the Calico Kubernetes 
-plugin.  This allows you to run Calico with the Kubernetes orchestrator.
-
-The `--rkt` flag configures your Calico node with the Calico rkt plugin, which 
-allows you to run Calico with the rkt orchestrator.
 
 The `--detach` option should be used if you are adding Calico to an init system.
 

--- a/docs/kubernetes/AWSIntegration.md
+++ b/docs/kubernetes/AWSIntegration.md
@@ -40,7 +40,7 @@ After a short delay, the kubelet on your master will automatically create a cont
 
 Next, use `calicoctl` to spin up the `calico/node` container and install the Calico [network plugin](https://github.com/projectcalico/calico-kubernetes) for Kubernetes. 
 ```
-sudo ETCD_AUTHORITY=<MASTER_IPV4>:6666 calicoctl node --kubernetes
+sudo ETCD_AUTHORITY=<MASTER_IPV4>:6666 calicoctl node
 ```
 
 Then you will need to set up an IP pool with IP-in-IP enabled. This is a [necessary step](../FAQ.md#can-i-run-calico-in-a-public-cloud-environment) in any public cloud environment.
@@ -76,7 +76,7 @@ Hold on to this token, as you will need it to configure your nodes.
 ## Configuring the Nodes
 On each node, use `calicoctl` to spin up the `calico/node` container and install the Calico [network plugin](https://github.com/projectcalico/calico-kubernetes) for Kubernetes. 
 ```
-sudo ETCD_AUTHORITY=<MASTER_IPV4>:6666 calicoctl node --kubernetes
+sudo ETCD_AUTHORITY=<MASTER_IPV4>:6666 calicoctl node
 ```
 
 To start using the Calico network plugin, we will need to modify the existing kubelet process on each of your nodes.

--- a/docs/kubernetes/KubernetesIntegration.md
+++ b/docs/kubernetes/KubernetesIntegration.md
@@ -38,9 +38,8 @@ wget http://www.projectcalico.org/latest/calicoctl
 sudo chmod +x calicoctl
 
 # Run the calico/node container
-sudo ETCD_AUTHORITY=<ETCD_IP>:<ETCD_PORT> ./calicoctl node --kubernetes
+sudo ETCD_AUTHORITY=<ETCD_IP>:<ETCD_PORT> ./calicoctl node
 ```
-> In the above commands, the `--kubernetes` option installs the `calico-kubernetes` plugin. 
 
 #### 2. Configure the Network Plugin 
 The Calico network plugin for Kubernetes uses the `calico_kubernetes.ini` file to read in user configuration.


### PR DESCRIPTION
Remove them from the calicoctl node command.
Removes install_binary too, the UTs and cleans up docs.