### PR TITLE
Support calico/ctl being run inside a container

### DIFF
--- a/calicoctl/Dockerfile
+++ b/calicoctl/Dockerfile
@@ -4,4 +4,6 @@ MAINTAINER Tom Denham <tom@projectcalico.org>
 ADD http://www.projectcalico.org/builds/calicoctl .
 RUN chmod +x calicoctl
 
+ENV CALICO_CTL_CONTAINER=TRUE
+
 ENTRYPOINT ["./calicoctl"]

--- a/calicoctl/Dockerfile
+++ b/calicoctl/Dockerfile
@@ -1,0 +1,7 @@
+FROM jeanblanchard/alpine-glibc
+MAINTAINER Tom Denham <tom@projectcalico.org>
+
+ADD http://www.projectcalico.org/builds/calicoctl .
+RUN chmod +x calicoctl
+
+ENTRYPOINT ["./calicoctl"]

--- a/calicoctl/calico_ctl/checksystem.py
+++ b/calicoctl/calico_ctl/checksystem.py
@@ -67,10 +67,15 @@ def checksystem(arguments):
                  libnetwork=arguments["--libnetwork"],
                  check_docker=check_docker)
 
-def check_system(quit_if_error=False, libnetwork=False, check_docker=True):
+
+def check_system(quit_if_error=False, libnetwork=False, check_docker=True,
+                 check_modules=True, check_etcd=True):
     """
     Checks that the system is setup correctly.
 
+    :param check_etcd: Whether to perform etcd checks.
+    :param check_docker: Whether to perform docker checks.
+    :param check_modules: Whether to perform module checks.
     :param quit_if_error: if True, quit with error code 1 if any issues are
     detected.
     :param libnetwork: If True, check for Docker version >= v1.21 to support libnetwork
@@ -80,9 +85,9 @@ def check_system(quit_if_error=False, libnetwork=False, check_docker=True):
     quit_if_error == True
     """
     enforce_root()
-    modules_ok = _check_modules()
+    modules_ok = _check_modules() if check_modules else True
     docker_ok = _check_docker_version(libnetwork) if check_docker else True
-    etcd_ok = _check_etcd_version()
+    etcd_ok = _check_etcd_version() if check_etcd else True
 
     system_ok = modules_ok and docker_ok and etcd_ok
 

--- a/calicoctl/calico_ctl/node.py
+++ b/calicoctl/calico_ctl/node.py
@@ -33,7 +33,7 @@ from subprocess32 import call
 from checksystem import check_system
 from connectors import client
 from connectors import docker_client
-from utils import REQUIRED_MODULES
+from utils import REQUIRED_MODULES, running_in_container
 from utils import get_container_ipv_from_arguments
 from utils import hostname
 from utils import print_paragraph
@@ -227,22 +227,23 @@ def node_start(node_image, runtime, log_dir, ip, ip6, as_num, detach,
     # We only make a best effort attempt because the command may fail if the
     # modules are built in.
     # We'll warn during the check_system() if the modules are unavailable.
-    try:
-        call(["modprobe", "-a"] + REQUIRED_MODULES)
-    except OSError:
-        pass
+    if not running_in_container():
+        try:
+            call(["modprobe", "-a"] + REQUIRED_MODULES)
+        except OSError:
+            pass
 
-    # Print warnings for any known system issues before continuing
-    using_docker = True if runtime == 'docker' else False
-    (_, _, etcd_ok) = \
-        check_system(quit_if_error=False, libnetwork=libnetwork_image,
-                     check_docker=using_docker)
+        # Print warnings for any known system issues before continuing
+        using_docker = True if runtime == 'docker' else False
+        (_, _, etcd_ok) = \
+            check_system(quit_if_error=False, libnetwork=libnetwork_image,
+                         check_docker=using_docker)
 
-    if not etcd_ok:
-        sys.exit(1)
+        if not etcd_ok:
+            sys.exit(1)
 
-    # We will always want to setup IP forwarding
-    _setup_ip_forwarding()
+        # We will always want to setup IP forwarding
+        _setup_ip_forwarding()
 
     # Ensure log directory exists
     if not os.path.exists(log_dir):

--- a/calicoctl/calico_ctl/node.py
+++ b/calicoctl/calico_ctl/node.py
@@ -233,17 +233,22 @@ def node_start(node_image, runtime, log_dir, ip, ip6, as_num, detach,
         except OSError:
             pass
 
-        # Print warnings for any known system issues before continuing
-        using_docker = True if runtime == 'docker' else False
+        # We will always want to setup IP forwarding
+        _setup_ip_forwarding()
+
+    # Print warnings for any known system issues before continuing
+        if runtime == 'docker' and not running_in_container():
+            using_docker = True
+        else:
+            using_docker = False
+
         (_, _, etcd_ok) = \
             check_system(quit_if_error=False, libnetwork=libnetwork_image,
-                         check_docker=using_docker)
+                         check_docker=using_docker,
+                         check_modules=not running_in_container())
 
         if not etcd_ok:
             sys.exit(1)
-
-        # We will always want to setup IP forwarding
-        _setup_ip_forwarding()
 
     # Ensure log directory exists
     if not os.path.exists(log_dir):

--- a/calicoctl/calico_ctl/utils.py
+++ b/calicoctl/calico_ctl/utils.py
@@ -51,7 +51,7 @@ def running_in_container():
     Check whether the current code is running in a container.
     :return: True if in a container. False otherwise.
     """
-    return os.path.isfile("/.dockerinit")
+    return os.getenv("CALICO_CTL_CONTAINER")
 
 def print_paragraph(msg, file=sys.stdout):
     """

--- a/calicoctl/calico_ctl/utils.py
+++ b/calicoctl/calico_ctl/utils.py
@@ -13,16 +13,15 @@
 # limitations under the License.
 from __future__ import print_function
 
-import socket
 import os
+import re
 import sys
 import textwrap
-import netaddr
-import re
 import urllib
 
-from pycalico.util import get_hostname
+import netaddr
 from netaddr.core import AddrFormatError
+from pycalico.util import get_hostname
 
 DOCKER_VERSION = "1.16"
 DOCKER_LIBNETWORK_VERSION = "1.21"
@@ -46,6 +45,13 @@ def enforce_root():
         print("This command must be run as root.", file=sys.stderr)
         sys.exit(2)
 
+
+def running_in_container():
+    """
+    Check whether the current code is running in a container.
+    :return: True if in a container. False otherwise.
+    """
+    return os.path.isfile("/.dockerinit")
 
 def print_paragraph(msg, file=sys.stdout):
     """

--- a/calicoctl/tests/unit/node_test.py
+++ b/calicoctl/tests/unit/node_test.py
@@ -184,7 +184,8 @@ class TestNode(unittest.TestCase):
     @patch('calico_ctl.node.docker', autospec=True)
     @patch('calico_ctl.node._find_or_pull_node_image', autospec=True)
     @patch('calico_ctl.node._attach_and_stream', autospec=True)
-    def test_node_dockerless_start(self, m_attach_and_stream,
+    @patch('calico_ctl.node.running_in_container', autospec=True)
+    def test_node_dockerless_start(self, m_container, m_attach_and_stream,
                                    m_find_or_pull_node_image, m_docker,
                                    m_docker_client, m_client,
                                    m_error_if_bgp_ip_conflict,
@@ -197,6 +198,7 @@ class TestNode(unittest.TestCase):
         without making Docker calls when runtime=none.
         """
         # Set up mock objects
+        m_container.return_value = False
         m_os_path_exists.return_value = False
         ip_1 = '1.1.1.1'
         ip_2 = '2.2.2.2'
@@ -225,7 +227,9 @@ class TestNode(unittest.TestCase):
         m_os_makedirs.assert_called_once_with(log_dir)
         m_check_system.assert_called_once_with(quit_if_error=False,
                                                libnetwork=libnetwork,
-                                               check_docker=False)
+                                               check_docker=False,
+                                               check_modules=True
+                                               )
         m_setup_ip.assert_called_once_with()
         m_get_host_ips.assert_called_once_with(exclude=["^docker.*", "^cbr.*",
                                                         "virbr.*", "lxcbr.*",
@@ -249,6 +253,7 @@ class TestNode(unittest.TestCase):
 
     @patch('os.path.exists', autospec=True)
     @patch('os.makedirs', autospec=True)
+    @patch('calico_ctl.node.running_in_container', autospec=True)
     @patch('calico_ctl.node._remove_host_tunnel_addr', autospec=True)
     @patch('calico_ctl.node._ensure_host_tunnel_addr', autospec=True)
     @patch('calico_ctl.node.check_system', autospec=True)
@@ -268,13 +273,14 @@ class TestNode(unittest.TestCase):
                         m_error_if_bgp_ip_conflict, m_warn_if_hostname_conflict,
                         m_warn_if_unknown_ip, m_get_host_ips, m_setup_ip,
                         m_check_system, m_ensure_host_tunnel_addr,
-                        m_remove_host_tunnel_addr, m_os_makedirs,
+                        m_remove_host_tunnel_addr, m_container, m_os_makedirs,
                         m_os_path_exists):
         """
         Test that the node_Start function does not make Docker calls
         function returns
         """
         # Set up mock objects
+        m_container.return_value = False
         m_os_path_exists.return_value = False
         ip_1 = '1.1.1.1'
         ip_2 = '2.2.2.2'
@@ -331,7 +337,8 @@ class TestNode(unittest.TestCase):
         m_os_makedirs.assert_called_once_with(log_dir)
         m_check_system.assert_called_once_with(quit_if_error=False,
                                                libnetwork=libnetwork,
-                                               check_docker=True)
+                                               check_docker=True,
+                                               check_modules=True)
         m_setup_ip.assert_called_once_with()
         m_get_host_ips.assert_called_once_with(exclude=["^docker.*", "^cbr.*",
                                                         "virbr.*", "lxcbr.*",
@@ -386,7 +393,8 @@ class TestNode(unittest.TestCase):
     @patch('calico_ctl.node.docker', autospec=True)
     @patch('calico_ctl.node._find_or_pull_node_image', autospec=True)
     @patch('calico_ctl.node._attach_and_stream', autospec=True)
-    def test_node_start_secure(self, m_attach_and_stream,
+    @patch('calico_ctl.node.running_in_container', autospec=True)
+    def test_node_start_secure(self, m_container, m_attach_and_stream,
                                m_find_or_pull_node_image, m_docker,
                                m_docker_client, m_client,
                                m_error_if_bgp_ip_conflict,
@@ -400,6 +408,7 @@ class TestNode(unittest.TestCase):
         secure etcd environment variables are present.
         """
         # Set up mock objects
+        m_container.return_value = False
         ip_1 = '1.1.1.1'
         ip_2 = '2.2.2.2'
         m_get_host_ips.return_value = [ip_1, ip_2]
@@ -487,7 +496,8 @@ class TestNode(unittest.TestCase):
         m_os_path_exists.assert_called_once_with(log_dir)
         m_check_system.assert_called_once_with(quit_if_error=False,
                                                libnetwork=libnetwork_image,
-                                               check_docker=True)
+                                               check_docker=True,
+                                               check_modules=True)
         m_setup_ip.assert_called_once_with()
         m_get_host_ips.assert_called_once_with(exclude=["^docker.*", "^cbr.*",
                                                         "virbr.*", "lxcbr.*",


### PR DESCRIPTION
Add dockerfile and better support in calicoctl node for ignoring things it can't do.

Fixes #309 