### PR TITLE
Documentation updates for Kubernetes v1alpha1 NetworkPolicy API.

### DIFF
--- a/docs/cni/kubernetes/AnnotationPolicy.md
+++ b/docs/cni/kubernetes/AnnotationPolicy.md
@@ -6,12 +6,19 @@
 > You are viewing the calico-docker documentation for release **release**.
 <!--- end of master only -->
 
+
+# Deprecated
+Annotation based policy has been deprecated in favor of the new Kubernetes `NetworkPolicy` v1alpha1 API.  It is recommended 
+that you switch to using the new API.
+
+Please see our documentation on [Calico and Kubernetes NetworkPolicy](NetworkPolicy.md).
+
 # Calico Policy for Kubernetes
 The Calico CNI plugin for Kubernetes allows you to specify network policy in the Kubernetes API using annotations.  
 > *Note*: annotation-based policy is currently experimental and is subject to change in future releases. 
 
 ## Prerequisites
-* A Kubernetes v1.1 Deployment using the Calico CNI plugin.
+* A Kubernetes v1.1 Deployment using the Calico CNI plugin v1.0+.
 * You must be using the iptables kube-proxy in your deployment. All of the Calico getting started guides configure the kube-proxy in this way.
 
 ## Behavior
@@ -230,4 +237,4 @@ spec:
 
 [k8s-network-model]: https://github.com/kubernetes/kubernetes/blob/master/docs/design/networking.md#networking
 
-[![Analytics](https://calico-ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/cni/kubernetes/Policy.md?pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://calico-ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/cni/kubernetes/AnnotationPolicy.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/cni/kubernetes/NetworkPolicy.md
+++ b/docs/cni/kubernetes/NetworkPolicy.md
@@ -1,0 +1,83 @@
+<!--- master only -->
+> ![warning](../../images/warning.png) This document applies to the HEAD of the calico-docker source tree.
+>
+> View the calico-docker documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.15.0/README.md).
+<!--- else
+> You are viewing the calico-docker documentation for release **release**.
+<!--- end of master only -->
+
+# Calico Policy for Kubernetes
+Calico supports the v1alpha1 network policy API for Kubernetes.
+> *Note*: The Kubernetes network policy API is currently in alpha and is subject to change. Calico support for this API is in beta and so is also subject to change. 
+
+## Prerequisites
+* A Kubernetes v1.1+ deployment using the [Calico CNI plugin v1.1](https://github.com/projectcalico/calico-cni/releases/latest) or greater.
+* You must be running the `calico/node:v0.17.0-k8s-policy` image on each Kubernetes node.  This is a beta pre-release image which supports this policy.
+* You must be using the iptables kube-proxy in your deployment. All of the Calico getting started guides configure the kube-proxy in this way.
+* You must have enabled `ThirdPartyResource` objects in your Kubernetes apiserver, as described [here](https://github.com/caseydavenport/kubernetes/blob/network-policy/docs/admin/network-policy.md#enabling-network-policy).
+
+## Behavior
+Calico implements the behavior of the Kubernetes [v1alpha1 network policy API](https://github.com/caseydavenport/kubernetes/blob/network-policy/docs/admin/network-policy.md#network-policy-in-kubernetes).
+
+## Enabling v1alpha1 policy support 
+
+To enable annotation-based policy in the Calico CNI plugin, add the `policy` section to your CNI network config file as shown - you will need to make this change on each Kubernetes worker node in your cluster (any node that allows scheduling of pods).  The CNI network configuration file can usually be found in the `/etc/cni/net.d/` directory.
+```
+$ cat /etc/cni/net.d/10-calico.conf
+{
+    "name": "calico-k8s-network",
+    "type": "calico",
+    "etcd_authority": "<ETCD_IP:ETCD_PORT>",
+    "log_level": "info",
+    "ipam": {
+        "type": "calico-ipam"
+    },
+    "policy": {
+        "type": "default-deny-inbound",
+    }
+}
+```
+
+This will disable inbound traffic to pods by default, delegating policy configuration to the [Calico policy agent](https://github.com/projectcalico/k8s-policy). 
+
+Once you have modified the network configuration file as shown above, you will need to restart the `kubelet` to pick up the changes.
+
+>Example for `systemd`:
+```
+sudo systemctl restart kubelet
+```
+
+## Running the Calico policy agent 
+In order to use the Kubernetes v1alpha1 network policy API, you must run the 
+Calico Kubernetes policy agent.  The policy agent runs as a pod on your 
+Kubernetes cluster.  It reads policy information from the Kubernetes API and 
+configures Calico appropriately. 
+
+To run the Calico Kubernetes policy agent:
+
+1. Download the policy services manifest file.
+```
+wget https://raw.githubusercontent.com/projectcalico/k8s-policy/master/examples/calico-policy-services.yaml
+```
+
+2. Replace `<ETCD_HOST>` and `<ETCD_PORT>` with the correct configuration to access your etcd cluster.
+
+3. Create the manifest file using `kubectl`.
+```
+kubectl create -f calico-policy-services.yaml
+```
+
+After a few moments, you should see the calico-policy-agent pod running in the `calico-system` namespace.
+```
+$ ./kubectl get pods --namespace=calico-system
+NAME                        READY     STATUS    RESTARTS   AGE
+calico-policy-agent-axg63   1/1       Running   0          1m
+```
+
+## Next Steps 
+- Install the [policy tool](https://github.com/projectcalico/k8s-policy/blob/master/policy_tool/README.md) for easy management of NetworkPolicy objects. 
+
+- Once you have enabled network policy on your cluster and configured Calico to use the Kubernetes network 
+policy API, you can deploy our [Kubernetes policy example application](stars-demo/README.md).
+
+[![Analytics](https://ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/cni/kubernetes/NetworkPolicy.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/cni/kubernetes/README.md
+++ b/docs/cni/kubernetes/README.md
@@ -24,7 +24,13 @@ Bare-metal guides:
 - [Ubuntu bare-metal](https://github.com/kubernetes/kubernetes/blob/master/docs/getting-started-guides/ubuntu-calico.md)
 
 # Kubernetes with Calico policy
-Calico can provide network policy for Kubernetes clusters.  This feature is currently experimental and disabled by default. [The policy documentation](Policy.md) explains how to enable and use Calico policy in a Kubernetes cluster.
+Calico can provide network policy for Kubernetes clusters using the v1alpha1 Kubernetes network-policy API.
+
+This feature is currently in alpha and disabled by default.  The following guide explains how to enable and use Calico policy on Kubernetes. 
+- [Kubernetes v1alpha1 Network Policy](NetworkPolicy.md)
+
+Calico also supports network policy using annotaions.  This method is deprecated, and as such is not recommended.
+- [Calico policy using Annotations](AnnotationPolicy.md) [Deprecated]
 
 # Requirements
 - The kube-proxy must be started in `iptables` proxy mode.

--- a/docs/cni/kubernetes/stars-demo/README.md
+++ b/docs/cni/kubernetes/stars-demo/README.md
@@ -1,0 +1,86 @@
+# Pre-requisites
+The included demo sets up a frontend and backend service, as well as a client service, all
+running on Kubernetes.  It then configures network policy on each service. 
+
+To create a Kubernetes cluster which supports the Kubernetes v1alpha1 network policy API, follow our [Vagrant CoreOS guide](../VagrantCoreOS.md).  
+This guide includes the [files necessary for this example](.).
+
+# Running the stars example 
+1) Log on to your Kubernetes master.
+```
+vagrant ssh calico-01
+```
+
+2) Download and configure the [policy tool](https://github.com/projectcalico/k8s-policy/blob/master/policy_tool/README.md) for NetworkPolicy management.
+```
+# Install the tool.
+wget https://github.com/projectcalico/k8s-policy/releases/download/v0.1.0/policy
+chmod +x ./policy
+sudo mv ./policy /opt/bin
+
+# Ensure the tool can access the API. This command will display an
+# error if the API is not reachable.
+policy list
+```
+
+3) Create the `frontend`, `backend`, `client`, and `management-ui` ReplicationControllers and Services.
+```
+kubectl create -f stars-demo/manifests/ 
+```
+
+Wait for all the pods to enter `Running` state.
+```
+watch kubectl get pods --all-namespaces
+```
+> Note that it may take several minutes to download the necessary Docker images for this demo.
+
+The management UI runs as a `NodePort` Service on Kubernetes, and shows the connectivity
+of the Services in this example.
+
+You can view the UI by visiting `http://172.18.18.102:30002` in a browser.
+
+Once all the pods are started, they should have full connectivity. You can see this by visiting the UI.  Each service is 
+represented by a single node in the graph.
+- `backend` -> Node "B"
+- `frontend` -> Node "F"
+- `client` -> Node "C" 
+
+4) Enable isolation
+```
+kubectl annotate ns stars "net.alpha.kubernetes.io/network-isolation=yes" --overwrite=true
+kubectl annotate ns client "net.alpha.kubernetes.io/network-isolation=yes" --overwrite=true
+```
+This will prevent all access to the frontend, backend, and client Services.
+
+Refresh the management UI (it may take up to 10 seconds for changes to be reflected in the UI).  
+Now that we've enabled isolation, the UI can no longer access the pods, and so they will no longer show up in the UI.  
+
+Allow the UI to access the Services using NetworkPolicy objects.
+```
+# Allow access from the management UI. 
+policy create -f stars-demo/policies/allow-ui.yaml
+policy create -f stars-demo/policies/allow-ui-client.yaml
+```
+
+After a few seconds, refresh the UI - it should now show the Services, but they should not be able to access each other any more.
+
+5) Create the "backend-policy.yaml" file to allow traffic from the frontend to the backend.
+```
+policy create -f stars-demo/policies/backend-policy.yaml
+```
+
+Refresh the UI.  You should see the following:
+- The frontend can now access the backend (on TCP port 80 only).
+- The backend cannot access the frontend at all.
+- The client cannot access the frontend, nor can it access the backend.
+
+6) Expose the frontend service to the `client` namespace.
+```
+policy create -f stars-demo/policies/frontend-policy.yaml
+```
+
+The client can now access the frontend, but not the backend.  Neither the frontend nor the backend 
+can initiate connections to the client.  The frontend can still access the backend.
+
+
+[![Analytics](https://calico-ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/cni/kubernetes/stars-demo/README.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/cni/kubernetes/stars-demo/manifests/backend.yaml
+++ b/docs/cni/kubernetes/stars-demo/manifests/backend.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend 
+  namespace: stars
+spec:
+  ports:
+  - port: 6379
+    targetPort: 6379 
+  selector:
+    tier: backend 
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: backend 
+  namespace: stars
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        tier: backend 
+    spec:
+      containers:
+      - name: backend 
+        image: caseydavenport/probe:calico-containers-demo
+        imagePullPolicy: Always
+        command:
+        - probe
+        - --http-port=6379
+        - --urls=http://frontend.stars.cluster.local:80/status,http://backend.stars.cluster.local:6379/status,http://client.client.cluster.local:9000/status
+        ports:
+        - containerPort: 6379 

--- a/docs/cni/kubernetes/stars-demo/manifests/client.yaml
+++ b/docs/cni/kubernetes/stars-demo/manifests/client.yaml
@@ -1,0 +1,40 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: client
+  labels:
+    role: client
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: client 
+  namespace: client
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        tier: client 
+    spec:
+      containers:
+      - name: client 
+        image: caseydavenport/probe:calico-containers-demo
+        imagePullPolicy: Always
+        command:
+        - probe
+        - --urls=http://frontend.stars.cluster.local:80/status,http://backend.stars.cluster.local:6379/status
+        ports:
+        - containerPort: 9000 
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: client
+  namespace: client
+spec:
+  ports:
+  - port: 9000 
+    targetPort: 9000
+  selector:
+    tier: client 

--- a/docs/cni/kubernetes/stars-demo/manifests/frontend.yaml
+++ b/docs/cni/kubernetes/stars-demo/manifests/frontend.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend 
+  namespace: stars
+spec:
+  type: NodePort
+  ports:
+  - port: 80 
+    targetPort: 80 
+  selector:
+    tier: frontend 
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: frontend 
+  namespace: stars
+spec:
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        tier: frontend 
+    spec:
+      containers:
+      - name: frontend 
+        image: caseydavenport/probe:calico-containers-demo
+        imagePullPolicy: Always
+        command:
+        - probe
+        - --http-port=80
+        - --urls=http://frontend.stars.cluster.local:80/status,http://backend.stars.cluster.local:6379/status,http://client.client.cluster.local:9000/status
+        ports:
+        - containerPort: 80 

--- a/docs/cni/kubernetes/stars-demo/manifests/management-ui.yaml
+++ b/docs/cni/kubernetes/stars-demo/manifests/management-ui.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: management-ui 
+  labels:
+    role: management-ui 
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: management-ui 
+  namespace: management-ui 
+spec:
+  type: NodePort
+  ports:
+  - port: 9001 
+    targetPort: 9001
+    nodePort: 30002
+  selector:
+    role: management-ui 
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: management-ui 
+  namespace: management-ui 
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        role: management-ui 
+    spec:
+      containers:
+      - name: management-ui 
+        image: caseydavenport/collect:calico-containers-demo
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 9001

--- a/docs/cni/kubernetes/stars-demo/manifests/namespace.yaml
+++ b/docs/cni/kubernetes/stars-demo/manifests/namespace.yaml
@@ -1,0 +1,4 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: stars

--- a/docs/cni/kubernetes/stars-demo/policies/allow-ui-client.yaml
+++ b/docs/cni/kubernetes/stars-demo/policies/allow-ui-client.yaml
@@ -1,0 +1,11 @@
+kind: NetworkPolicy
+apiVersion: net.alpha.kubernetes.io/v1alpha1
+metadata:
+  namespace: client 
+  name: allow-ui 
+spec:
+  podSelector:
+  ingress:
+    - from:
+        - namespaces:
+            role: management-ui 

--- a/docs/cni/kubernetes/stars-demo/policies/allow-ui.yaml
+++ b/docs/cni/kubernetes/stars-demo/policies/allow-ui.yaml
@@ -1,0 +1,11 @@
+kind: NetworkPolicy
+apiVersion: net.alpha.kubernetes.io/v1alpha1
+metadata:
+  namespace: stars
+  name: allow-ui 
+spec:
+  podSelector:
+  ingress:
+    - from:
+        - namespaces:
+            role: management-ui 

--- a/docs/cni/kubernetes/stars-demo/policies/backend-policy.yaml
+++ b/docs/cni/kubernetes/stars-demo/policies/backend-policy.yaml
@@ -1,0 +1,15 @@
+kind: NetworkPolicy
+apiVersion: net.alpha.kubernetes.io/v1alpha1
+metadata:
+  namespace: stars
+  name: backend-policy
+spec:
+  podSelector:
+    tier: backend
+  ingress:
+    - from:
+        - pods:
+            tier: frontend
+      ports:
+        - protocol: TCP
+          port: 6379

--- a/docs/cni/kubernetes/stars-demo/policies/frontend-policy.yaml
+++ b/docs/cni/kubernetes/stars-demo/policies/frontend-policy.yaml
@@ -1,0 +1,15 @@
+kind: NetworkPolicy
+apiVersion: net.alpha.kubernetes.io/v1alpha1
+metadata:
+  namespace: stars
+  name: frontend-policy
+spec:
+  podSelector:
+    tier: frontend 
+  ingress:
+    - from:
+        - namespaces:
+            role: client
+      ports:
+        - protocol: TCP
+          port: 80

--- a/docs/cni/kubernetes/vagrant-coreos/Vagrantfile
+++ b/docs/cni/kubernetes/vagrant-coreos/Vagrantfile
@@ -1,5 +1,5 @@
 # Size of the cluster created by Vagrant
-num_instances=2
+num_instances=3
 
 # Change basename of the VM
 instance_name_prefix="calico"
@@ -36,12 +36,14 @@ Vagrant.configure("2") do |config|
         # Configure the master.
         host.vm.provision :file, :source => "../manifests/skydns.yaml", :destination => "/home/core/skydns.yaml"
         host.vm.provision :file, :source => "../manifests/guestbook.yaml", :destination => "/home/core/guestbook.yaml"
-        host.vm.provision :file, :source => "../cloud-config/master-config.yaml", :destination => "/tmp/vagrantfile-user-data"
+        host.vm.provision :file, :source => "cloud-config/master-config.yaml", :destination => "/tmp/vagrantfile-user-data"
+        host.vm.provision :file, :source => "manifests/calico-policy-services.yaml", :destination => "/home/core/calico-policy-services.yaml"
+        host.vm.provision :file, :source => "../stars-demo", :destination => "/home/core/stars-demo"
         host.vm.provision :shell, :inline => "mv /tmp/vagrantfile-user-data /var/lib/coreos-vagrant/", :privileged => true
       else
         # Configure a node.
 	host.vm.provision :docker, images: ["busybox:latest", "gcr.io/google_containers/pause:0.8.0"] 
-        host.vm.provision :file, :source => "../cloud-config/node-config.yaml", :destination => "/tmp/vagrantfile-user-data"
+        host.vm.provision :file, :source => "cloud-config/node-config.yaml", :destination => "/tmp/vagrantfile-user-data"
         host.vm.provision :shell, :inline => "mv /tmp/vagrantfile-user-data /var/lib/coreos-vagrant/", :privileged => true
       end
     end

--- a/docs/cni/kubernetes/vagrant-coreos/cloud-config/master-config.yaml
+++ b/docs/cni/kubernetes/vagrant-coreos/cloud-config/master-config.yaml
@@ -89,10 +89,10 @@ coreos:
         User=root
         Environment="ETCD_AUTHORITY=localhost:2379"
         PermissionsStartOnly=true
-        ExecStartPre=/usr/bin/wget -N -P /opt/bin http://www.projectcalico.org/builds/calicoctl
+        ExecStartPre=/usr/bin/wget -O /opt/bin/calicoctl http://www.projectcalico.org/builds/calicoctl
         ExecStartPre=/usr/bin/chmod +x /opt/bin/calicoctl
-        ExecStartPre=/opt/bin/calicoctl pool add 192.168.0.0/16 --ipip --nat-outgoing
-        ExecStart=/opt/bin/calicoctl node --ip=$private_ipv4 --detach=false
+        ExecStartPre=/opt/bin/calicoctl pool add 192.168.0.0/16 --nat-outgoing
+        ExecStart=/opt/bin/calicoctl node --ip=$private_ipv4 --detach=false --node-image=calico/node:v0.17.0-k8s-policy
         Restart=always
         RestartSec=10
 

--- a/docs/cni/kubernetes/vagrant-coreos/cloud-config/node-config.yaml
+++ b/docs/cni/kubernetes/vagrant-coreos/cloud-config/node-config.yaml
@@ -9,10 +9,13 @@ write_files:
       {
           "name": "calico-k8s-network",
           "type": "calico",
-          "etcd_authority": "kubernetes-master:2379",
+          "etcd_authority": "172.18.18.101:2379",
           "log_level": "info",
           "ipam": {
               "type": "calico-ipam"
+          },
+          "policy": {
+              "type": "default-deny-inbound"
           }
       }
 
@@ -26,7 +29,7 @@ write_files:
       clusters:
       - name: local
         cluster:
-          server: http://kubernetes-master:8080
+          server: http://172.18.18.101:8080
       users:
       - name: kubelet
       contexts:
@@ -40,7 +43,7 @@ coreos:
   etcd2:
     proxy: on 
     listen-client-urls: http://localhost:2379
-    initial-cluster: etcdserver=http://kubernetes-master:2380
+    initial-cluster: etcdserver=http://172.18.18.101:2380
   fleet:
     metadata: "role=node"
     etcd_servers: "http://localhost:2379"
@@ -62,11 +65,11 @@ coreos:
         
         [Service]
         User=root
-        Environment=ETCD_AUTHORITY=kubernetes-master:2379
+        Environment=ETCD_AUTHORITY=172.18.18.101:2379
         PermissionsStartOnly=true
-        ExecStartPre=/usr/bin/wget -N -P /opt/bin http://www.projectcalico.org/builds/calicoctl
+        ExecStartPre=/usr/bin/wget -O /opt/bin/calicoctl http://www.projectcalico.org/builds/calicoctl
         ExecStartPre=/usr/bin/chmod +x /opt/bin/calicoctl
-        ExecStart=/opt/bin/calicoctl node --ip=$private_ipv4 --detach=false
+        ExecStart=/opt/bin/calicoctl node --ip=$private_ipv4 --detach=false --node-image=calico/node:v0.17.0-k8s-policy
         Restart=always
         RestartSec=10
 
@@ -86,7 +89,8 @@ coreos:
         [Service]
         ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v1.1.8/bin/linux/amd64/kubelet
         ExecStartPre=/usr/bin/chmod +x /opt/bin/kubelet
-        ExecStartPre=/usr/bin/wget -N -P /opt/cni/bin https://github.com/projectcalico/calico-cni/releases/download/v1.0.0/calico 
+        ExecStartPre=/usr/bin/mkdir -p /opt/cni/bin
+        ExecStartPre=/usr/bin/wget -O /opt/cni/bin/calico https://github.com/projectcalico/calico-cni/releases/download/v1.1.0/calico 
         ExecStartPre=/usr/bin/chmod +x /opt/cni/bin/calico
         ExecStart=/opt/bin/kubelet \
         --address=0.0.0.0 \
@@ -95,7 +99,7 @@ coreos:
         --cluster-domain=cluster.local \
         --config=/etc/kubernetes/manifests \
         --hostname-override=$private_ipv4 \
-        --api-servers=http://kubernetes-master:8080 \
+        --api-servers=http://172.18.18.101:8080 \
         --network-plugin-dir=/etc/cni/net.d \
         --network-plugin=cni \
         --logtostderr=true
@@ -117,7 +121,7 @@ coreos:
         ExecStartPre=/usr/bin/wget -N -P /opt/bin  https://storage.googleapis.com/kubernetes-release/release/v1.1.8/bin/linux/amd64/kube-proxy
         ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-proxy
         ExecStart=/opt/bin/kube-proxy \
-        --master=http://kubernetes-master:8080 \
+        --master=http://172.18.18.101:8080 \
         --proxy-mode=iptables \
         --logtostderr=true
         Restart=always

--- a/docs/cni/kubernetes/vagrant-coreos/guestbook.md
+++ b/docs/cni/kubernetes/vagrant-coreos/guestbook.md
@@ -1,0 +1,39 @@
+# Deploying the guestbook application
+The following steps describe how to deploy the Kubernetes [guestbook application][guestbook].
+
+This guide assumes you have a Kubernetes cluster as configured by the [Vagrant CoreOS guide](../VagrantCoreOS.md)
+
+1) Log on to the master node.
+```
+vagrant ssh calico-01
+```
+
+2) Create the guestbook application pods and services using the provided manifest.
+```
+kubectl create -f guestbook.yaml
+```
+
+3) Check that the redis-master, redis-slave, and frontend pods are running correctly.  After a few minutes, the following command should show all pods in `Running` state.
+```
+kubectl get pods
+```
+> Note: The guestbook demo relies on a number of docker images which may take up to 5 minutes to download.
+
+4) Check that Calico endpoints have been created for the guestbook pods.
+```
+calicoctl endpoint show --detailed
+```
+
+5) The above manifests configure a web appliation that is exposed on port 30001 on each of your nodes using the Kubernetes NodePort mechanism. 
+```
+kubectl describe svc frontend
+```
+The service is available internally via a `10.100.0.X` IP address on port `80`, and outside the cluster using the NodePort `30001`.
+
+To access the guestbook application frontend, visit `http://172.18.18.101:30001` in your favorite browser.  Because we used a NodePort service to expose it outside the cluster, it should also be available at `http://172.18.18.102:30001`.
+
+
+[guestbook]: https://github.com/kubernetes/kubernetes/blob/master/examples/guestbook/README.md
+
+
+[![Analytics](https://calico-ga-beacon.appspot.com/UA-52125893-3/calico-containers/docs/cni/kubernetes/vagrant-coreos/guestbook.md?pixel)](https://github.com/igrigorik/ga-beacon)

--- a/docs/cni/kubernetes/vagrant-coreos/manifests/calico-policy-services.yaml
+++ b/docs/cni/kubernetes/vagrant-coreos/manifests/calico-policy-services.yaml
@@ -1,0 +1,39 @@
+kind: ThirdPartyResource
+apiVersion: extensions/v1beta1
+metadata:
+  name: network-policy.net.alpha.kubernetes.io
+description: "Specification for a network isolation policy"
+versions:
+- name: v1alpha1
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: calico-system
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: calico-policy-agent
+  namespace: calico-system 
+  labels:
+    version: v0.1.0
+    projectcalico.org/app: "policy-agent"
+spec:
+  replicas: 1
+  selector:
+    version: v0.1.0
+    projectcalico.org/app: "policy-agent"
+  template:
+    metadata:
+      labels:
+        version: v0.1.0
+        projectcalico.org/app: "policy-agent"
+    spec:
+      containers:
+        - name: policyagent
+          image: calico/k8s-policy-agent:v0.1.0
+          imagePullPolicy: Always
+          env:
+          - name: ETCD_AUTHORITY
+            value: "172.18.18.101:2379"


### PR DESCRIPTION
Work in progress, just getting the pieces into the right place.

Still needs:
- [x] Example policies e.g "kubectl create -f policy-demo/" 
- [x] Release which includes policy Felix
- [x] calico-cni release
- [x] calico policy agent release