### PR TITLE
Vagrant installs use Docker 1.10.1

### DIFF
--- a/docs/calico-with-docker/AWS.md
+++ b/docs/calico-with-docker/AWS.md
@@ -158,9 +158,11 @@ A different file is used for the two servers.
 Copy these files onto your machine.
 
 Before running the commands, note the following:
--  The `ami-########` represents the CoreOS stable HVM image type for the `us-west-2` region. 
-If you are using a region other than `us-west-2`, replace the image name with the correct CoreOS stable HVM image 
-from the [CoreOS image list](https://coreos.com/os/docs/latest/booting-on-ec2.html) for your zone. 
+-  The `ami-########` represents the CoreOS alpha HVM image type for the `us-west-2` region
+(version 976.0.0 as of the writing of this document). The alpha version is used because it
+supports Docker 1.10. If you are using a region other than `us-west-2`, replace the
+image name with the correct CoreOS alpha HVM image from the [CoreOS image
+list](https://coreos.com/os/docs/latest/booting-on-ec2.html) for your zone. 
 Use `aws ec2 describe-availability-zones` to display your region if you do not remember.
 -  It may take a couple of minutes for AWS to boot the machines after creating them.
 
@@ -168,7 +170,7 @@ For the first server run:
 
 ```
 aws ec2 run-instances \
-  --image-id ami-99bfada9 \
+  --image-id ami-2b7d914b \
   --instance-type t2.micro \
   --key-name mykey \
   --security-group-ids $SECURITY_GROUP_ID \

--- a/docs/calico-with-docker/GCE.md
+++ b/docs/calico-with-docker/GCE.md
@@ -66,7 +66,7 @@ For the first server run:
 gcloud compute instances create \
   calico-1 \
   --image-project coreos-cloud \
-  --image coreos-alpha-709-0-0-v20150611 \
+  --image coreos-alpha-976-0-0-v20160304 \
   --machine-type n1-standard-1 \
   --metadata-from-file user-data=<PATH_TO_CLOUD_CONFIG>/user-data-first
 ```
@@ -79,7 +79,7 @@ Then, for the second server, run:
 gcloud compute instances create \
   calico-2 \
   --image-project coreos-cloud \
-  --image coreos-alpha-709-0-0-v20150611 \
+  --image coreos-alpha-976-0-0-v20160304 \
   --machine-type n1-standard-1 \
   --metadata-from-file user-data=<PATH_TO_CLOUD_CONFIG>/user-data-others
 ```

--- a/docs/calico-with-docker/docker-network-plugin/cloud-config/user-data-first
+++ b/docs/calico-with-docker/docker-network-plugin/cloud-config/user-data-first
@@ -27,18 +27,6 @@ coreos:
       Type=oneshot
       ExecStart=/home/core/add_path.sh
       ExecStart=/home/core/get_calicoctl.sh
-  - name: download-latest.service
-    command: start
-    content: |-
-      [Unit]
-      Description=Download and unpack the prereqs
-      Wants=download-reqs.service
-      After=download-reqs.service
-
-      [Service]
-      RemainAfterExit=yes
-      Type=oneshot
-      ExecStart=/home/core/get_latest_docker.sh
   - name: docker.service
     command: restart
     content: |-
@@ -52,7 +40,7 @@ coreos:
       MountFlags=slave
       LimitNOFILE=1048576
       LimitNPROC=1048576
-      ExecStart=/opt/bin/docker --cluster-store=etcd://$private_ipv4:2379 --daemon --host=fd:// $DOCKER_OPTS $DOCKER_OPT_BIP $DOCKER_OPT_MTU $DOCKER_OPT_IPMASQ
+      ExecStart=/usr/bin/docker daemon --cluster-store=etcd://$private_ipv4:2379 --host=fd:// $DOCKER_OPTS $DOCKER_OPT_BIP $DOCKER_OPT_MTU $DOCKER_OPT_IPMASQ
       RestartSec=10
       Restart=always
 
@@ -68,16 +56,9 @@ write_files:
     # Can't directly write to .profile since it's a symlink to a RO filesystem
     mkdir -p /opt/bin
     rm /home/core/.bashrc
-    echo 'PATH=/opt/bin:$PATH' > /home/core/.bashrc
+    echo 'PATH=$PATH:/opt/bin' > /home/core/.bashrc
     echo 'export ETCD_AUTHORITY="$private_ipv4:2379"' >> /home/core/.bashrc
     echo 'Defaults env_keep +="ETCD_AUTHORITY"' >>/etc/sudoers.d/etcd
-- path: /home/core/get_latest_docker.sh
-  permissions: 777
-  owner: root
-  content: |
-    #!/usr/bin/bash -e
-    wget -O /opt/bin/docker https://get.docker.com/builds/Linux/x86_64/docker-1.9.0
-    chmod +x opt/bin/docker
 - path: /home/core/get_calicoctl.sh
   permissions: 777
   owner: root

--- a/docs/calico-with-docker/docker-network-plugin/cloud-config/user-data-others
+++ b/docs/calico-with-docker/docker-network-plugin/cloud-config/user-data-others
@@ -22,18 +22,6 @@ coreos:
       Type=oneshot
       ExecStart=/home/core/add_path.sh
       ExecStart=/home/core/get_calicoctl.sh
-  - name: download-latest.service
-    command: start
-    content: |-
-      [Unit]
-      Description=Download and unpack the prereqs
-      Wants=download-reqs.service
-      After=download-reqs.service
-
-      [Service]
-      RemainAfterExit=yes
-      Type=oneshot
-      ExecStart=/home/core/get_latest_docker.sh
   - name: docker.service
     command: restart
     content: |-
@@ -47,7 +35,7 @@ coreos:
       MountFlags=slave
       LimitNOFILE=1048576
       LimitNPROC=1048576
-      ExecStart=/opt/bin/docker --cluster-store=etcd://172.17.8.101:2379 --daemon --host=fd:// $DOCKER_OPTS $DOCKER_OPT_BIP $DOCKER_OPT_MTU $DOCKER_OPT_IPMASQ
+      ExecStart=/usr/bin/docker daemon --cluster-store=etcd://172.17.8.101:2379 --host=fd:// $DOCKER_OPTS $DOCKER_OPT_BIP $DOCKER_OPT_MTU $DOCKER_OPT_IPMASQ
       RestartSec=10
       Restart=always
 
@@ -63,16 +51,9 @@ write_files:
     # Can't directly write to .profile since it's a symlink to a RO filesystem
     mkdir -p /opt/bin
     rm /home/core/.bashrc
-    echo 'PATH=/opt/bin:$PATH' > /home/core/.bashrc
+    echo 'PATH=$PATH:/opt/bin' > /home/core/.bashrc
     echo 'export ETCD_AUTHORITY="172.17.8.101:2379"' >> /home/core/.bashrc
     echo 'Defaults env_keep +="ETCD_AUTHORITY"' >>/etc/sudoers.d/etcd
-- path: /home/core/get_latest_docker.sh
-  permissions: 777
-  owner: root
-  content: |
-    #!/usr/bin/bash -e
-    wget -O /opt/bin/docker https://get.docker.com/builds/Linux/x86_64/docker-1.9.0
-    chmod +x opt/bin/docker
 - path: /home/core/get_calicoctl.sh
   permissions: 777
   owner: root

--- a/docs/calico-with-docker/docker-network-plugin/vagrant-coreos/Vagrantfile
+++ b/docs/calico-with-docker/docker-network-plugin/vagrant-coreos/Vagrantfile
@@ -27,7 +27,7 @@ Vagrant.configure("2") do |config|
   config.ssh.insert_key = false
 
   config.vm.box = "coreos-%s" % update_channel
-  config.vm.box_version = ">= 308.0.1"
+  config.vm.box_version = ">= 962.0.0"
   config.vm.box_url = "http://%s.release.core-os.net/amd64-usr/current/coreos_production_vagrant.json" % update_channel
 
   config.vm.provider :virtualbox do |v|

--- a/docs/calico-with-docker/docker-network-plugin/vagrant-ubuntu/Vagrantfile
+++ b/docs/calico-with-docker/docker-network-plugin/vagrant-ubuntu/Vagrantfile
@@ -51,9 +51,9 @@ Vagrant.configure(2) do |config|
           "calico/node:#{calico_node_ver}"
       ]
 
-      # Replace docker with the latest master build
+      # Replace docker with the docker 1.10.1 build
       host.vm.provision :shell, inline: "stop docker", :privileged => true
-      host.vm.provision :shell, inline: "wget -qO /usr/bin/docker https://get.docker.com/builds/Linux/x86_64/docker-1.9.0", :privileged => true
+      host.vm.provision :shell, inline: "wget -qO /usr/bin/docker https://get.docker.com/builds/Linux/x86_64/docker-1.10.1", :privileged => true
 
       # Calico uses etcd for calico and docker clustering. Install it on the first host only.
       if i == 1

--- a/docs/calico-with-docker/without-docker-networking/vagrant-coreos/Vagrantfile
+++ b/docs/calico-with-docker/without-docker-networking/vagrant-coreos/Vagrantfile
@@ -26,7 +26,7 @@ Vagrant.configure("2") do |config|
   config.ssh.insert_key = false
 
   config.vm.box = "coreos-%s" % update_channel
-  config.vm.box_version = ">= 308.0.1"
+  config.vm.box_version = ">= 962.0.0"
   config.vm.box_url = "http://%s.release.core-os.net/amd64-usr/current/coreos_production_vagrant.json" % update_channel
 
   config.vm.provider :virtualbox do |v|

--- a/docs/calico-with-docker/without-docker-networking/vagrant-ubuntu/Vagrantfile
+++ b/docs/calico-with-docker/without-docker-networking/vagrant-ubuntu/Vagrantfile
@@ -51,8 +51,11 @@ Vagrant.configure(2) do |config|
 
       # download calicoctl.
       host.vm.provision :shell, inline: "wget -qO /usr/local/bin/calicoctl #{calicoctl_url}", :privileged => true
-
       host.vm.provision :shell, inline: "chmod +x /usr/local/bin/calicoctl"
+
+      # Replace docker with the docker 1.10.1 build
+      host.vm.provision :shell, inline: "stop docker", :privileged => true
+      host.vm.provision :shell, inline: "wget -qO /usr/bin/docker https://get.docker.com/builds/Linux/x86_64/docker-1.10.1", :privileged => true
 
       # Calico uses etcd for clustering. Install it on the first host only.
       if i == 1


### PR DESCRIPTION
Removed unnecessary cloud-config that installed docker 1.9 on CoreOS vagrant machines. Alpha CoreOS machines build come with docker 1.10.1 by default.  Modified Ubuntu vagrant docker binaries to be 1.10.1 also.
Fixes #837 

This change also fixes the bug where the docker images were not being pulled during the vagrant install (since there were two different docker binaries on the machine, the incorrect binary was pulling the images).
Fixes #838 