### PR TITLE
Fixed calico start failure bug

### DIFF
--- a/calico_node/filesystem/startup.py
+++ b/calico_node/filesystem/startup.py
@@ -247,7 +247,7 @@ def main():
                                     "virbr.*", "lxcbr.*", "veth.*",
                                     "cali.*", "tunl.*", "flannel.*"])
         try:
-            ip = ips.pop()
+            ip = str(ips.pop())
         except IndexError:
             print "Couldn't autodetect a management IP address. Please " \
                   "provide an IP address by rerunning the container with the" \

--- a/tests/st/no_orchestrator/test_mainline_single_host.py
+++ b/tests/st/no_orchestrator/test_mainline_single_host.py
@@ -51,6 +51,44 @@ class TestNoOrchestratorSingleHost(TestBase):
             host.calicoctl("node stop")
             host.calicoctl("node remove")
 
+    def test_single_host_autodetect_ipv4(self):
+        """
+        Run a standard Mainline functionality test without using an orchestrator plugin. However,
+        this test also configures the test framework to not pass in the --ip flag to calicoctl,
+        forcing calicoctl to do IP address detection.
+        :return:
+        """
+        with DockerHost('host', dind=False, calico_node_autodetect_ip=True) as host:
+            host.calicoctl("status")
+            host.calicoctl("profile add TEST_GROUP")
+
+            # Create a workload on each host.
+            workload1 = host.create_workload("workload1")
+            workload2 = host.create_workload("workload2")
+
+            # Add the nodes to Calico networking.
+            host.calicoctl("container add %s 192.168.1.1" % workload1)
+            host.calicoctl("container add %s 192.168.1.2" % workload2)
+
+            # Now add the profiles - one using set and one using append
+            host.calicoctl("container %s profile set TEST_GROUP" % workload1)
+            host.calicoctl("container %s profile append TEST_GROUP" % workload2)
+
+            # TODO - assert on output of endpoint show and endpoint profile
+            # show commands.
+
+            # Check it works
+            workload1.assert_can_ping("192.168.1.2", retries=3)
+            workload2.assert_can_ping("192.168.1.1", retries=3)
+
+            # Test the teardown commands
+            host.calicoctl("profile remove TEST_GROUP")
+            host.calicoctl("container remove %s" % workload1)
+            host.calicoctl("container remove %s" % workload2)
+            host.calicoctl("pool remove 192.168.0.0/16")
+            host.calicoctl("node stop")
+            host.calicoctl("node remove")
+
     @unittest.skipUnless(HOST_IPV6, "Host does not have an IPv6 address")
     def test_single_host_ipv6(self):
         """


### PR DESCRIPTION
Fixed bug where calicoctl node would fail to start up without being passed --ip, due to a failure to convert ipaddress to a string