### PR TITLE
Fix semaphore builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,10 +195,10 @@ add-ssl-hostname:
 	fi
 
 semaphore: docker
-	# Use the downloaded docker locally, not just with Docker in Docker STs
-	service docker stop
-	cp ./docker $(shell which docker)
-	service docker start
+	# Our traditional method of overwriting the docker binary doesn't seem to work
+	# for docker 1.11.0+. Semaphore has updated to 1.11.0, so, for now, we can
+	# just use the installed docker. In the future, when we must update docker,
+	# we should investigate how to do it properly.
 	docker version
 
 	# Clean up unwanted files to free disk space.


### PR DESCRIPTION
Couple of things going on here.
- Semaphore did a platform update on 4/26 which bumped docker to 1.11.0.
- The initial cause of ST failure was because our script was overwriting the install docker binary with a 1.10.1 binary. Due to the platform upgrade, this resulted in us downgrading docker. The 1.11 install comes with some flags which are unsupported in 1.10, so docker was failing to start after the downgrade. 

For now, this PR fixes builds by not installing the downloaded docker 1.10.0 on the host. This means we still download 1.10.0, which still gets uses it in the docker-in-docker builds. Therefore dind is now using a different version of docker than the host.

This opens subsequent work to update dind to 1.11.0. However, Its not as straightforward as it seems:
- Docker has updated how they distribute docker binaries, and they no longer just have a static link to a binary, but a [tgz of several docker binaries](https://docs.docker.com/engine/installation/binaries/#get-the-linux-binaries) which all must be available in `$PATH`. We'll need to update dind to meet this requirement.
