### PR TITLE
Use correct IP type in node startup with get_host_ips change

### DIFF
--- a/calico_node/filesystem/startup.py
+++ b/calico_node/filesystem/startup.py
@@ -247,7 +247,7 @@ def main():
                                     "virbr.*", "lxcbr.*", "veth.*",
                                     "cali.*", "tunl.*", "flannel.*"])
         try:
-            ip = ips.pop()
+            ip = str(ips.pop())
         except IndexError:
             print "Couldn't autodetect a management IP address. Please " \
                   "provide an IP address by rerunning the container with the" \


### PR DESCRIPTION
`get_host_ips` now returns an IPAddress object, but this function is expecting a string IP.