### PR TITLE
[DO NOT MERGE] Mesos docker-compose CNI demo

### DIFF
--- a/docs/mesos/cni/docker-compose/.gitignore
+++ b/docs/mesos/cni/docker-compose/.gitignore
@@ -1,0 +1,1 @@
+docker-compose

--- a/docs/mesos/cni/docker-compose/Dockerfile
+++ b/docs/mesos/cni/docker-compose/Dockerfile
@@ -1,0 +1,48 @@
+FROM djosborne/mesos-modules-dev-phusion:master
+MAINTAINER Dan Osborne <dan@projectcalico.org>
+
+####################
+# Mesos-DNS
+####################
+RUN curl -LO https://github.com/mesosphere/mesos-dns/releases/download/v0.5.0/mesos-dns-v0.5.0-linux-amd64 && \
+    mv mesos-dns-v0.5.0-linux-amd64 /usr/bin/mesos-dns && \
+    chmod +x /usr/bin/mesos-dns
+
+###################
+# Docker
+###################
+RUN apt-get update -qq && apt-get install -qqy \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    lxc \
+    iptables
+
+# Install Docker from Docker Inc. repositories.
+RUN curl -sSL https://get.docker.com/ | sh
+
+# Define additional metadata for our image.
+VOLUME /var/lib/docker
+
+#################
+# Init scripts
+#################
+ADD ./init_scripts/etc/service/mesos_slave/run /etc/service/mesos_slave/run
+ADD ./init_scripts/etc/service/docker/run /etc/service/docker/run
+ADD ./init_scripts/etc/service/calico/run /etc/service/calico/run
+ADD ./init_scripts/etc/service/mesos-dns/run /etc/service/mesos-dns/run
+ADD ./init_scripts/etc/config/mesos-dns.json /etc/config/mesos-dns.json
+
+
+######################
+# Calico
+######################
+COPY ./calico/ /calico/
+ADD https://github.com/projectcalico/calico-docker/releases/download/v0.19.0/calicoctl /usr/local/bin/calicoctl 
+RUN chmod +x /usr/local/bin/calicoctl
+ADD https://github.com/projectcalico/calico-cni/releases/download/v1.3.0/calico /cni/bin/calico
+RUN chmod +x /cni/bin/calico
+ADD https://github.com/projectcalico/calico-cni/releases/download/v1.3.0/calico-ipam /cni/bin/calico-ipam
+RUN chmod +x /cni/bin/calico-ipam
+
+ADD ./cni/ /cni/

--- a/docs/mesos/cni/docker-compose/Makefile
+++ b/docs/mesos/cni/docker-compose/Makefile
@@ -1,0 +1,29 @@
+CALICO_NODE_VERSION=v0.19.0
+DOCKER_COMPOSE_URL=https://github.com/docker/compose/releases/download/1.4.0/docker-compose-`uname -s`-`uname -m`
+
+default: images
+
+docker-compose:
+	  curl -L ${DOCKER_COMPOSE_URL} > docker-compose
+	  chmod +x ./docker-compose
+
+calico-node: calico/calico-node-$(CALICO_NODE_VERSION).tar
+
+calico/calico-node-$(CALICO_NODE_VERSION).tar:
+	docker pull calico/node:$(CALICO_NODE_VERSION)
+	docker save -o calico/calico-node-$(CALICO_NODE_VERSION).tar calico/node:$(CALICO_NODE_VERSION)
+
+images: calico-node docker-compose
+	  ./docker-compose pull
+	  ./docker-compose build
+
+clean:
+	./docker-compose kill
+	./docker-compose rm --force
+
+cluster: images
+	./docker-compose up -d
+	./docker-compose scale slave=3
+
+test-cni:
+	docker exec dockercompose_slave_1 mesos-execute --containerizer=mesos --docker_image=busybox --name=cni --master=172.17.0.4:5050 --networks=calico-net-1 --command=ifconfig

--- a/docs/mesos/cni/docker-compose/cni/conf/calico-net-1.conf
+++ b/docs/mesos/cni/docker-compose/cni/conf/calico-net-1.conf
@@ -1,0 +1,8 @@
+{
+    "name": "calico-net-1",
+    "type": "calico",
+    "ipam": {
+        "type": "calico-ipam"
+    },
+    "etcd_authority": "etcd:2379"
+}

--- a/docs/mesos/cni/docker-compose/cni/conf/calico-net-2.conf
+++ b/docs/mesos/cni/docker-compose/cni/conf/calico-net-2.conf
@@ -1,0 +1,8 @@
+{
+    "name": "calico-net-2",
+    "type": "calico",
+    "ipam": {
+        "type": "calico-ipam"
+    },
+    "etcd_authority": "etcd:2379"
+}

--- a/docs/mesos/cni/docker-compose/docker-compose.yml
+++ b/docs/mesos/cni/docker-compose/docker-compose.yml
@@ -1,0 +1,63 @@
+zookeeper:
+  image: jplock/zookeeper:3.4.5
+  hostname: zookeeper
+
+mesosmaster:
+  image: djosborne/mesos-modules-dev:master
+  hostname: mesosmaster
+  command: /mesos/build/bin/mesos-master.sh
+  environment:
+    - MESOS_QUORUM=1
+    - MESOS_WORK_DIR=/var/lib/mesos
+    - MESOS_LOG_DIR=/var/log
+    - MESOS_ZK=zk://zookeeper:2181/mesos
+    - MESOS_ROLES=public
+  volumes:
+    - /var/log/mesos:/var/log/mesos
+    - ./framework/:/framework
+  ports:
+    - "5050:5050"
+  links:
+    - zookeeper
+
+slave:
+  build: .
+  privileged: true
+  links:
+    - mesosmaster
+    - zookeeper
+    - etcd
+  volumes:
+    - /var/log/mesos:/var/log/mesos
+    - ./framework:/framework
+  environment:
+    - MESOS_MASTER=zk://zookeeper:2181/mesos
+    - MESOS_EXECUTOR_REGISTRATION_TIMEOUT=5mins
+    - MESOS_CONTAINERIZERS=mesos
+    - MESOS_ISOLATOR=cgroups/cpu,cgroups/mem
+    - MESOS_LOG_DIR=/var/log
+    - MESOS_RESOURCES=ports(*):[9000-31100]
+    - MESOS_NETWORK_CNI_PLUGINS_DIR=/cni/bin/
+    - MESOS_NETWORK_CNI_CONFIG_DIR=/cni/conf/
+    - MESOS_ISOLATION=filesystem/linux,docker/runtime
+    - MESOS_IMAGE_PROVIDERS=docker
+  dns:
+   - 192.168.255.254
+
+marathon:
+  image: mesosphere/marathon:v0.14.0
+  environment:
+    - MARATHON_MASTER=zk://zookeeper:2181/mesos
+    - MARATHON_ZK=zk://zookeeper:2181/marathon
+    - MARATHON_MAX_TASKS_PER_OFFER=32
+  ports:
+    - "8080:8080"
+  links:
+    - mesosmaster
+    - zookeeper
+
+etcd:
+  image: quay.io/coreos/etcd:v2.0.11
+  environment:
+    - ETCD_ADVERTISE_CLIENT_URLS=http://etcd:2379,http://etcd:4001
+    - ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379,http://0.0.0.0:4001

--- a/docs/mesos/cni/docker-compose/init_scripts/etc/config/mesos-dns.json
+++ b/docs/mesos/cni/docker-compose/init_scripts/etc/config/mesos-dns.json
@@ -1,0 +1,22 @@
+{
+  "zk": "",
+  "masters": ["mesosmaster:5050"],
+  "refreshSeconds": 5,
+  "ttl": 60,
+  "domain": "mesos",
+  "port": 53,
+  "resolvers": ["8.8.8.8"],
+  "timeout": 5,
+  "httpon": true,
+  "dsnon": true,
+  "httpport": 8123,
+  "externalon": true,
+  "listener": "0.0.0.0",
+  "SOAMname": "root.ns1.mesos",
+  "SOARname": "ns1.mesos",
+  "SOARefresh": 60,
+  "SOARetry":   600,
+  "SOAExpire":  86400,
+  "SOAMinttl": 60,
+  "IPSources": ["netinfo", "mesos", "host"]
+}

--- a/docs/mesos/cni/docker-compose/init_scripts/etc/rc.local
+++ b/docs/mesos/cni/docker-compose/init_scripts/etc/rc.local
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Record current boot time. Helps with debugging.
+date > /tmp/boottime.txt

--- a/docs/mesos/cni/docker-compose/init_scripts/etc/service/calico/run
+++ b/docs/mesos/cni/docker-compose/init_scripts/etc/service/calico/run
@@ -1,0 +1,8 @@
+#!/bin/sh
+IP=`ip addr | grep 'global eth0' | awk '{print $2}' | cut -f1  -d'/'`
+ETCD_IP=`getent hosts etcd | awk '{ print $2 }'`
+while ! docker ps; do sleep 1; done
+docker load -i /calico/calico-node-v0.19.0.tar
+export ETCD_AUTHORITY=$ETCD_IP:4001
+exec 2>&1
+exec calicoctl node --ip=$IP --detach=false --node-image=calico/node:v0.19.0

--- a/docs/mesos/cni/docker-compose/init_scripts/etc/service/mesos-dns/run
+++ b/docs/mesos/cni/docker-compose/init_scripts/etc/service/mesos-dns/run
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+ip addr add 192.168.255.254/32 dev lo
+
+# Start mesos-dns on this slave
+exec mesos-dns -config=/etc/config/mesos-dns.json

--- a/docs/mesos/cni/docker-compose/init_scripts/etc/service/mesos_slave/run
+++ b/docs/mesos/cni/docker-compose/init_scripts/etc/service/mesos_slave/run
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+# Based on https://github.com/jpetazzo/dind
+
+# Ensure that all nodes in /dev/mapper correspond to mapped devices currently loaded by the device-mapper kernel driver
+dmsetup mknodes
+
+# First, make sure that cgroups are mounted correctly.
+CGROUP=/sys/fs/cgroup
+: {LOG:=stdio}
+
+[ -d $CGROUP ] ||
+	mkdir $CGROUP
+
+mountpoint -q $CGROUP ||
+	mount -n -t tmpfs -o uid=0,gid=0,mode=0755 cgroup $CGROUP || {
+		echo "Could not make a tmpfs mount. Did you use --privileged?"
+		exit 1
+	}
+
+if [ -d /sys/kernel/security ] && ! mountpoint -q /sys/kernel/security
+then
+    mount -t securityfs none /sys/kernel/security || {
+        echo "Could not mount /sys/kernel/security."
+        echo "AppArmor detection and --privileged mode might break."
+    }
+fi
+
+# Mount the cgroup hierarchies exactly as they are in the parent system.
+for SUBSYS in $(cut -d: -f2 /proc/1/cgroup)
+do
+        [ -d $CGROUP/$SUBSYS ] || mkdir $CGROUP/$SUBSYS
+        mountpoint -q $CGROUP/$SUBSYS ||
+                mount -n -t cgroup -o $SUBSYS cgroup $CGROUP/$SUBSYS
+
+        # The two following sections address a bug which manifests itself
+        # by a cryptic "lxc-start: no ns_cgroup option specified" when
+        # trying to start containers withina container.
+        # The bug seems to appear when the cgroup hierarchies are not
+        # mounted on the exact same directories in the host, and in the
+        # container.
+
+        # Named, control-less cgroups are mounted with "-o name=foo"
+        # (and appear as such under /proc/<pid>/cgroup) but are usually
+        # mounted on a directory named "foo" (without the "name=" prefix).
+        # Systemd and OpenRC (and possibly others) both create such a
+        # cgroup. To avoid the aforementioned bug, we symlink "foo" to
+        # "name=foo". This shouldn't have any adverse effect.
+        echo $SUBSYS | grep -q ^name= && {
+                NAME=$(echo $SUBSYS | sed s/^name=//)
+                ln -s $SUBSYS $CGROUP/$NAME
+        }
+
+        # Likewise, on at least one system, it has been reported that
+        # systemd would mount the CPU and CPU accounting controllers
+        # (respectively "cpu" and "cpuacct") with "-o cpuacct,cpu"
+        # but on a directory called "cpu,cpuacct" (note the inversion
+        # in the order of the groups). This tries to work around it.
+        [ $SUBSYS = cpuacct,cpu ] && ln -s $SUBSYS $CGROUP/cpu,cpuacct
+done
+
+# Note: as I write those lines, the LXC userland tools cannot setup
+# a "sub-container" properly if the "devices" cgroup is not in its
+# own hierarchy. Let's detect this and issue a warning.
+grep -q :devices: /proc/1/cgroup ||
+	echo "WARNING: the 'devices' cgroup should be in its own hierarchy."
+grep -qw devices /proc/1/cgroup ||
+	echo "WARNING: it looks like the 'devices' cgroup is not mounted."
+
+# Now, close extraneous file descriptors.
+pushd /proc/self/fd >/dev/null
+for FD in *
+do
+	case "$FD" in
+	# Keep stdin/stdout/stderr
+	[012])
+		;;
+	# Nuke everything else
+	*)
+		eval exec "$FD>&-"
+		;;
+	esac
+done
+popd >/dev/null
+
+IP=`ip addr | grep 'global eth0' | awk '{print $2}' | cut -f1  -d'/'`
+/mesos/build/bin/mesos-slave.sh --ip=$IP --hostname=$IP

--- a/docs/mesos/cni/docker-compose/mesos-modules-dev-phusion/Dockerfile
+++ b/docs/mesos/cni/docker-compose/mesos-modules-dev-phusion/Dockerfile
@@ -1,0 +1,71 @@
+FROM phusion/baseimage
+MAINTAINER Mesosphere <support@mesosphere.io>
+
+# Install Dependencies
+
+RUN apt-get update -q --fix-missing
+RUN apt-get -qy install software-properties-common # (for add-apt-repository)
+RUN add-apt-repository ppa:george-edison55/cmake-3.x
+RUN apt-get update -q
+RUN apt-cache policy cmake
+RUN apt-get -qy install \
+  build-essential                         \
+  autoconf                                \
+  automake                                \
+  cmake=3.2.2-2~ubuntu14.04.1~ppa1 \
+  ca-certificates                         \
+  gdb                                     \
+  wget                                    \
+  git-core                                \
+  libcurl4-nss-dev                        \
+  libsasl2-dev                            \
+  libtool                                 \
+  libsvn-dev                              \
+  libapr1-dev                             \
+  libgoogle-glog-dev                      \
+  libboost-dev                            \
+  protobuf-compiler                       \
+  libprotobuf-dev                         \
+  make                                    \
+  python                                  \
+  python2.7                               \
+  libpython-dev                           \
+  python-dev                              \
+  python-protobuf                         \
+  python-setuptools                       \
+  heimdal-clients                         \
+  libsasl2-modules-gssapi-heimdal         \
+  unzip                                   \
+  --no-install-recommends
+
+# Install the picojson headers
+RUN wget https://raw.githubusercontent.com/kazuho/picojson/v1.3.0/picojson.h -O /usr/local/include/picojson.h
+
+# Prepare to build Mesos
+RUN mkdir -p /mesos
+RUN mkdir -p /tmp
+RUN mkdir -p /usr/share/java/
+RUN wget http://search.maven.org/remotecontent?filepath=com/google/protobuf/protobuf-java/2.5.0/protobuf-java-2.5.0.jar -O protobuf.jar
+RUN mv protobuf.jar /usr/share/java/
+
+WORKDIR /mesos
+
+# Clone Mesos (master branch)
+RUN git clone git://git.apache.org/mesos.git /mesos
+RUN git checkout master
+RUN git log -n 1
+
+# Bootstrap
+RUN ./bootstrap
+
+# Configure
+RUN mkdir build && cd build && ../configure --disable-java --disable-optimize --without-included-zookeeper
+
+# Build Mesos
+RUN cd build && make -j 2 install
+
+# Install python eggs
+RUN easy_install /mesos/build/src/python/dist/mesos.interface-*.egg
+RUN easy_install /mesos/build/src/python/dist/mesos.executor-*.egg
+RUN easy_install /mesos/build/src/python/dist/mesos.scheduler-*.egg
+RUN easy_install /mesos/build/src/python/dist/mesos.native-*.egg

--- a/docs/mesos/cni/docker-compose/mesos-modules-dev/Dockerfile
+++ b/docs/mesos/cni/docker-compose/mesos-modules-dev/Dockerfile
@@ -1,0 +1,71 @@
+FROM ubuntu-upstart:14.04
+MAINTAINER Mesosphere <support@mesosphere.io>
+
+# Install Dependencies
+
+RUN apt-get update -q --fix-missing
+RUN apt-get -qy install software-properties-common # (for add-apt-repository)
+RUN add-apt-repository ppa:george-edison55/cmake-3.x
+RUN apt-get update -q
+RUN apt-cache policy cmake
+RUN apt-get -qy install \
+  build-essential                         \
+  autoconf                                \
+  automake                                \
+  cmake=3.2.2-2~ubuntu14.04.1~ppa1 \
+  ca-certificates                         \
+  gdb                                     \
+  wget                                    \
+  git-core                                \
+  libcurl4-nss-dev                        \
+  libsasl2-dev                            \
+  libtool                                 \
+  libsvn-dev                              \
+  libapr1-dev                             \
+  libgoogle-glog-dev                      \
+  libboost-dev                            \
+  protobuf-compiler                       \
+  libprotobuf-dev                         \
+  make                                    \
+  python                                  \
+  python2.7                               \
+  libpython-dev                           \
+  python-dev                              \
+  python-protobuf                         \
+  python-setuptools                       \
+  heimdal-clients                         \
+  libsasl2-modules-gssapi-heimdal         \
+  unzip                                   \
+  --no-install-recommends
+
+# Install the picojson headers
+RUN wget https://raw.githubusercontent.com/kazuho/picojson/v1.3.0/picojson.h -O /usr/local/include/picojson.h
+
+# Prepare to build Mesos
+RUN mkdir -p /mesos
+RUN mkdir -p /tmp
+RUN mkdir -p /usr/share/java/
+RUN wget http://search.maven.org/remotecontent?filepath=com/google/protobuf/protobuf-java/2.5.0/protobuf-java-2.5.0.jar -O protobuf.jar
+RUN mv protobuf.jar /usr/share/java/
+
+WORKDIR /mesos
+
+# Clone Mesos (master branch)
+RUN git clone git://git.apache.org/mesos.git /mesos
+RUN git checkout master
+RUN git log -n 1
+
+# Bootstrap
+RUN ./bootstrap
+
+# Configure
+RUN mkdir build && cd build && ../configure --disable-java --disable-optimize --without-included-zookeeper
+
+# Build Mesos
+RUN cd build && make -j 4 install
+
+# Install python eggs
+RUN easy_install /mesos/build/src/python/dist/mesos.interface-*.egg
+RUN easy_install /mesos/build/src/python/dist/mesos.executor-*.egg
+RUN easy_install /mesos/build/src/python/dist/mesos.scheduler-*.egg
+RUN easy_install /mesos/build/src/python/dist/mesos.native-*.egg


### PR DESCRIPTION
This is a demo based on the net-modules docker-compose demo. It uses dind to quickly spin up a full mesos cluster useful for testing Mesos CNI. Marking as DNM until we are ready to support this for demo purposes as well.

Dockerfiles are included for the slave and master base images.