### PR TITLE
Exit with status 1 when node container quits with bad status

### DIFF
--- a/calicoctl/calico_ctl/node.py
+++ b/calicoctl/calico_ctl/node.py
@@ -836,6 +836,7 @@ def _attach_and_stream(container, startup_only):
         sys.exit(0)
     signal.signal(signal.SIGTERM, handle_sigterm)
     stop_container_on_exit = True
+    exit_code = 1
 
     output = docker_client.attach(container, stream=True)
     try:
@@ -847,8 +848,12 @@ def _attach_and_stream(container, startup_only):
     except KeyboardInterrupt:
         # Mainline. Someone pressed Ctrl-C.
         print "Stopping Calico node..."
+        stop_container_on_exit = True
+        exit_code = 130
     finally:
         # Could either be this process is being killed, or output generator
         # raises an exception.
         if stop_container_on_exit:
             docker_client.stop(container)
+            # If the container is stopped, some sort of error occurred.
+            sys.exit(exit_code)

--- a/calicoctl/tests/unit/node_test.py
+++ b/calicoctl/tests/unit/node_test.py
@@ -94,6 +94,7 @@ class TestAttachAndStream(unittest.TestCase):
                                          call("from the container.")])
         self.assertEqual(m_stdout.write.call_count, 2)
         m_docker_client.stop.assert_called_once_with(m_container)
+        m_sys.exit.assertcalled_once_with(130)
 
     @patch("calico_ctl.node.docker_client", spec=DockerClient)
     @patch("calico_ctl.node.sys", spec=sys)
@@ -121,7 +122,6 @@ class TestAttachAndStream(unittest.TestCase):
         m_docker_client.attach.assert_called_once_with(m_container,
                                                        stream=True)
         self.assertFalse(m_container.called)
-        m_sys.exit.assert_called_once_with(0)
         m_stdout.write.assert_has_calls([call("Some output\n"),
                                          call("from the container."),
                                          call("\nThis output is printed, but "
@@ -134,6 +134,9 @@ class TestAttachAndStream(unittest.TestCase):
         m_docker_client.stop.assert_has_calls([call(m_container),
                                                call(m_container)])
         self.assertEqual(m_docker_client.stop.call_count, 2)
+        # sys.exit gets called twice: once when handling the SIGTERM and once
+        # when stopping the container for an unknown reason
+        m_sys.exit.assert_has_calls([call(0), call(1)])
 
 
 class TestNode(unittest.TestCase):


### PR DESCRIPTION
Fixes #920 

When the node fails due to some unknown error to `calicoctl`, `calicoctl` still exits with status 0.

Easily reproducable scenario is starting the calico node, changing hostname, then restarting the calico node.  `calicoctl` will show that the container did not start, but status is still 0.

This change ensures we are setting a clean status if we are expecting to shut down the container, otherwise exit with status 1.