### PR TITLE
Use new validate_port_spec to validate port spec

### DIFF
--- a/calicoctl/calico_ctl/profile.py
+++ b/calicoctl/calico_ctl/profile.py
@@ -77,7 +77,7 @@ from pycalico.datastore import Rules
 from connectors import client, DOCKER_URL
 from utils import print_paragraph, DOCKER_LIBNETWORK_VERSION
 from pycalico.datastore_datatypes import Profile
-from pycalico.util import (validate_characters, validate_ports,
+from pycalico.util import (validate_characters, validate_port_str,
                            validate_icmp_type, validate_cidr, validate_cidr_versions)
 
 
@@ -131,7 +131,7 @@ def validate_arguments(arguments):
     ports_ok = True
     for arg in ["<SRCPORTS>", "<DSTPORTS>"]:
         if arguments.get(arg) is not None:
-            ports_ok = validate_ports(arguments[arg])
+            ports_ok = validate_port_str(arguments[arg])
             if not ports_ok:
                 break
 

--- a/calicoctl/tests/unit/profile_test.py
+++ b/calicoctl/tests/unit/profile_test.py
@@ -37,9 +37,9 @@ class TestProfile(unittest.TestCase):
         ({'<ICMPTYPE>':'16'}, False),
         ({'<ICMPCODE>':100, '<ICMPTYPE>':100}, False),
         ({'<ICMPCODE>':4, '<ICMPTYPE>':255}, True),
-        ({'<SRCPORTS>':[6,9,10], '<DSTPORTS>':[66,88,95]}, False),
-        ({'<SRCPORTS>':[6,9,-10], '<DSTPORTS>':[66,88,95]}, True),
-        ({'<SRCPORTS>':['53:99'], '<DSTPORTS>':[66,88,95]}, False),
+        ({'<SRCPORTS>':'6,9,10', '<DSTPORTS>':'66,88,95'}, False),
+        ({'<SRCPORTS>':'6,9,-10', '<DSTPORTS>':'66,88,95'}, True),
+        ({'<SRCPORTS>':'53:99', '<DSTPORTS>':'66,88,95'}, False),
         ({}, False)
     ])
     def test_validate_arguments(self, case, sys_exit_called):
@@ -448,4 +448,3 @@ class TestProfile(unittest.TestCase):
         # Call method under test
         self.assertRaises(SystemExit, profile_rule_add_remove,
                           operation, name, position, action, direction)
-


### PR DESCRIPTION
(Instead of validate_ports.  validate_port_spec validates the port
specifications that can be specified on the calicoctl command line. This
is different from validate_ports, which validates the port values that
can occur in the etcd data model.)