### PR TITLE
Change dind from volume mount to official dind image

### DIFF
--- a/calico_test/Dockerfile
+++ b/calico_test/Dockerfile
@@ -11,9 +11,23 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM jeanblanchard/alpine-glibc
+FROM docker
 MAINTAINER Tom Denham <tom@projectcalico.org>
-
+# Install iptables, ip6tables, iproute2, and perform glibc install as per:
+# https://github.com/jeanblanchard/docker-alpine-glibc/blob/master/Dockerfile
+# We install glibc onto the official docker image (instead of adding docker to 
+# the libc image) since glibc installs are more constant than the 
+# docker-in-docker installaction and configuration.
+RUN apk add --update iptables ip6tables iproute2 curl && \
+  curl -o glibc.apk -L "https://github.com/andyshinn/alpine-pkg-glibc/releases/download/2.23-r1/glibc-2.23-r1.apk" && \
+  apk add --allow-untrusted glibc.apk && \
+  curl -o glibc-bin.apk -L "https://github.com/andyshinn/alpine-pkg-glibc/releases/download/2.23-r1/glibc-bin-2.23-r1.apk" && \
+  apk add --allow-untrusted glibc-bin.apk && \
+  /usr/glibc-compat/sbin/ldconfig /lib /usr/glibc/usr/lib && \
+  echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf && \
+  apk del curl && \
+  rm -f glibc.apk glibc-bin.apk && \
+  rm -rf /var/cache/apk/*
 RUN apk --update add python py-setuptools iproute2 iputils ip6tables ipset
 
 # Could make this container smaller by merging the next three lines with a remove.
@@ -26,7 +40,4 @@ ADD tests tests
 
 # The container is used by mounting the code-under-test to /code
 WORKDIR /code/
-RUN ln -s /code/docker /usr/local/bin/docker
-
-
 

--- a/calico_test/tests/st/utils/docker_host.py
+++ b/calico_test/tests/st/utils/docker_host.py
@@ -56,10 +56,10 @@ class DockerHost(object):
         # cleaned up.  If not used as a context manager, users of this object
         self._cleaned = False
 
-        docker_args = "--privileged -tid -v %s/docker:/usr/local/bin/docker " \
+        docker_args = "--privileged -tid " \
                       "-v /lib/modules:/lib/modules " \
                       "-v %s/certs:%s/certs -v %s:/code --name %s" % \
-                      (CHECKOUT_DIR, CHECKOUT_DIR, CHECKOUT_DIR, CHECKOUT_DIR,
+                      (CHECKOUT_DIR, CHECKOUT_DIR, CHECKOUT_DIR,
                        self.name)
         if ETCD_SCHEME == "https":
             docker_args += " --add-host %s:%s" % (ETCD_HOSTNAME_SSL, get_ip())
@@ -68,9 +68,12 @@ class DockerHost(object):
             log_and_run("docker rm -f %s || true" % self.name)
             # Pass the certs directory as a volume since the etcd SSL/TLS
             # environment variables use the full path on the host.
+            # Set iptables=false to prevent iptables error when using dind libnetwork
             log_and_run("docker run %s "
                         "calico/dind:latest "
-                        "docker daemon --storage-driver=aufs %s" %
+                        " --storage-driver=aufs "
+                        "--iptables=false "
+                        "%s" %
                     (docker_args, additional_docker_options))
 
             self.ip = log_and_run("docker inspect --format "


### PR DESCRIPTION
Update calico/containers to adhere to changes in [#1](https://github.com/projectcalico/dind/pull/1) whereby we no longer volume mount docker in from the host, but the new calico/dind which is built from the official dind image