### PR TITLE
Prevent installation of docker 1.10 in vagrantfile

### DIFF
--- a/docs/calico-with-docker/docker-network-plugin/vagrant-ubuntu/Vagrantfile
+++ b/docs/calico-with-docker/docker-network-plugin/vagrant-ubuntu/Vagrantfile
@@ -51,10 +51,6 @@ Vagrant.configure(2) do |config|
           "calico/node:#{calico_node_ver}"
       ]
 
-      # Replace docker with the docker 1.10.1 build
-      host.vm.provision :shell, inline: "stop docker", :privileged => true
-      host.vm.provision :shell, inline: "wget -qO /usr/bin/docker https://get.docker.com/builds/Linux/x86_64/docker-1.10.1", :privileged => true
-
       # Calico uses etcd for calico and docker clustering. Install it on the first host only.
       if i == 1
         # Download etcd and start.
@@ -70,7 +66,7 @@ Vagrant.configure(2) do |config|
       host.vm.provision :shell, inline: %Q|sudo sh -c 'echo "DOCKER_OPTS=\"--cluster-store=etcd://#{primary_ip}:2379\"" > /etc/default/docker'|
 
       # Restart docker.
-      host.vm.provision :shell, inline: "sudo start docker"
+      host.vm.provision :shell, inline: "restart docker"
 
       # download calicoctl.
       host.vm.provision :shell, inline: "wget -qO /usr/local/bin/calicoctl #{calicoctl_url}", :privileged => true

--- a/docs/calico-with-docker/without-docker-networking/vagrant-ubuntu/Vagrantfile
+++ b/docs/calico-with-docker/without-docker-networking/vagrant-ubuntu/Vagrantfile
@@ -53,10 +53,6 @@ Vagrant.configure(2) do |config|
       host.vm.provision :shell, inline: "wget -qO /usr/local/bin/calicoctl #{calicoctl_url}", :privileged => true
       host.vm.provision :shell, inline: "chmod +x /usr/local/bin/calicoctl"
 
-      # Replace docker with the docker 1.10.1 build
-      host.vm.provision :shell, inline: "stop docker", :privileged => true
-      host.vm.provision :shell, inline: "wget -qO /usr/bin/docker https://get.docker.com/builds/Linux/x86_64/docker-1.10.1", :privileged => true
-
       # Calico uses etcd for clustering. Install it on the first host only.
       if i == 1
         host.vm.provision :docker do |d|


### PR DESCRIPTION
The vagrant docker provisioner installs different versions of docker depending on which version of vagrant you're using. If you're using the latest vagrant, this means docker 1.11. The 1.11 base installation includes flags unsupported in 1.10. So the lines I've removed in this PR would otherwise downgrade docker and break since the daemon is configured with 1.11 flags