### PR TITLE
changed old reference for the calicoctl build in the cloud-config for Vagrant 

### DIFF
--- a/docs/calico-with-docker/docker-network-plugin/cloud-config/user-data-first
+++ b/docs/calico-with-docker/docker-network-plugin/cloud-config/user-data-first
@@ -64,5 +64,5 @@ write_files:
   owner: root
   content: |
     #!/usr/bin/bash -e
-    wget -O /opt/bin/calicoctl http://www.projectcalico.org/builds/calicoctl
+    wget -O /opt/bin/calicoctl https://github.com/projectcalico/calico-containers/releases/download/v0.19.0/calicoctl 
     chmod +x /opt/bin/calicoctl

--- a/docs/calico-with-docker/docker-network-plugin/cloud-config/user-data-others
+++ b/docs/calico-with-docker/docker-network-plugin/cloud-config/user-data-others
@@ -59,5 +59,5 @@ write_files:
   owner: root
   content: |
     #!/usr/bin/bash -e
-    wget -O /opt/bin/calicoctl http://www.projectcalico.org/builds/calicoctl
+    wget -O /opt/bin/calicoctl https://github.com/projectcalico/calico-containers/releases/download/v0.19.0/calicoctl
     chmod +x /opt/bin/calicoctl


### PR DESCRIPTION
Following the online [documentation](https://github.com/projectcalico/calico-containers/blob/master/docs/calico-with-docker/docker-network-plugin/README.md):
```
rbucchi@ws-bucchi:(master)calico-containers$ cd docs/calico-with-docker/docker-network-plugin/vagrant-coreos/
rbucchi@ws-bucchi:(master)vagrant-coreos$ ls
Vagrantfile
rbucchi@ws-bucchi:(master)vagrant-coreos$ vagrant up
Bringing machine 'calico-01' up with 'virtualbox' provider...
Bringing machine 'calico-02' up with 'virtualbox' provider...
....
rbucchi@ws-bucchi:(master)vagrant-coreos$ vagrant ssh calico-01
CoreOS alpha (1032.1.0)
Last login: Tue May 17 14:16:51 2016 from 10.0.2.2
Update Strategy: No Reboots
Failed Units: 1
  download-reqs.service

core@calico-01 ~ $ journalctl -xe -u download-reqs.service
-- 
-- The result is failed.
May 17 14:15:34 calico-01 systemd[1]: download-reqs.service: Unit entered failed state.
May 17 14:15:34 calico-01 systemd[1]: download-reqs.service: Failed with result 'exit-code'.
May 17 14:15:34 calico-01 systemd[1]: Starting Download and unpack the prereqs...
-- Subject: Unit download-reqs.service has begun start-up
-- Defined-By: systemd
-- Support: http://lists.freedesktop.org/mailman/listinfo/systemd-devel
-- 
-- Unit download-reqs.service has begun starting up.
May 17 14:15:34 calico-01 get_calicoctl.sh[1448]: --2016-05-17 14:15:34--  http://www.projectcalico.org/builds/calicoctl
May 17 14:15:34 calico-01 get_calicoctl.sh[1448]: Resolving www.projectcalico.org... 162.242.219.8, 162.242.219.8
May 17 14:15:34 calico-01 get_calicoctl.sh[1448]: Connecting to www.projectcalico.org|162.242.219.8|:80... connected.
May 17 14:15:34 calico-01 get_calicoctl.sh[1448]: HTTP request sent, awaiting response... 301 Moved Permanently
May 17 14:15:34 calico-01 get_calicoctl.sh[1448]: Location: https://www.projectcalico.org/builds/calicoctl [following]
May 17 14:15:34 calico-01 get_calicoctl.sh[1448]: --2016-05-17 14:15:34--  https://www.projectcalico.org/builds/calicoctl
May 17 14:15:34 calico-01 get_calicoctl.sh[1448]: Connecting to www.projectcalico.org|162.242.219.8|:443... connected.
May 17 14:15:35 calico-01 get_calicoctl.sh[1448]: HTTP request sent, awaiting response... 404 Not Found
May 17 14:15:35 calico-01 get_calicoctl.sh[1448]: 2016-05-17 14:15:35 ERROR 404: Not Found.
May 17 14:15:35 calico-01 systemd[1]: download-reqs.service: Main process exited, code=exited, status=8/n/a
May 17 14:15:35 calico-01 systemd[1]: Failed to start Download and unpack the prereqs.
-- Subject: Unit download-reqs.service has failed
-- Defined-By: systemd
-- Support: http://lists.freedesktop.org/mailman/listinfo/systemd-devel
-- 
-- Unit download-reqs.service has failed.

core@calico-01 ~ $ sudo calicoctl node --libnetwork
sudo: calicoctl: command not found
```
There's a simple old reference to www.projectcalico.org/builds/calicoctl which not exist anymore. I pointed to https://github.com/projectcalico/calico-containers/releases/download/v0.19.0/calicoctl  

```
rbucchi@ws-bucchi:(master)vagrant-coreos$ vagrant ssh calico-01
CoreOS alpha (1032.1.0)
Last login: Tue May 17 14:23:47 2016 from 10.0.2.2
Update Strategy: No Reboots
core@calico-01 ~ $ sudo calicoctl node --libnetwork                                                                                                                                                           
Pulling Docker image calico/node:v0.19.0

Running Docker container with the following command:

docker run -d --restart=always --net=host --privileged --name=calico-node -e HOSTNAME=calico-01 -e IP= -e IP6= -e CALICO_NETWORKING=true -e AS= -e NO_DEFAULT_POOLS= -e ETCD_AUTHORITY=172.17.8.101:2379 -e ETCD_SCHEME=http -v /var/log/calico:/var/log/calico -v /lib/modules:/lib/modules -v /var/run/calico:/var/run/calico calico/node:v0.19.0

Calico node is running with id: 93b9412d5e659a57db967e499fc9654acb52764cd9430707c85b61802c35b47b
Waiting for successful startup
No IP provided. Using detected IP: 172.17.8.101
Calico node started successfully
Pulling Docker image calico/node-libnetwork:v0.8.0

Calico libnetwork driver is running with id: 353d489867d6f6581ef6d7289a70601c9161eeb2c84127576cbdfa1f5f4dd371
core@calico-01 ~ $ 
```