### PR TITLE
Add doc section in Docker containerizer install to set cluster-store

### DIFF
--- a/docs/mesos/ManualInstallCalicoDockerContainerizer.md
+++ b/docs/mesos/ManualInstallCalicoDockerContainerizer.md
@@ -13,9 +13,16 @@ for use with the Docker Containerizer in Mesos.
 
 ## Prerequisites
 
-You will need to configure your Docker daemon on each agent to point at
-the etcd cluster store, as seen in our [Manual Setup guide]
-(../calico-with-docker/docker-network-plugin/ManualSetup.md#docker).
+### Docker
+
+To use the multi-host native networking feature of Docker, the Docker daemon
+needs to be run with the cluster store parameter.  If using etcd as a cluster
+store, run the Docker daemon with the following additional parameter:
+
+    --cluster-store=etcd://<ETCD HOST>:<PORT>
+
+Replacing `<ETCD HOST>:<PORT>` with the appropriate `IP/Hostname:Port`
+for your etcd cluster.
 
 ## Install and Run Calico
 It is very easy to install Calico to use with the
@@ -39,10 +46,10 @@ For test environments that you would like to get up and running
 quickly, you can run the `calicoctl node --libnetwork`:
 
 ```
-sudo ETCD_AUTHORITY=<HOST:PORT> ./calicoctl node --libnetwork
+sudo ETCD_AUTHORITY=<ETCD HOST:PORT> ./calicoctl node --libnetwork
 ```
 
-> Be sure to set the ETCD_AUTHORITY to the correct `IP/Hostname:Port` for your etcd cluster.
+Again, be sure to set the ETCD_AUTHORITY to the correct `IP/Hostname:Port` for your etcd cluster.
 
 Once you've started the Calico services or you've run the `node` command,
 you should see two Calico containers running in Docker:


### PR DESCRIPTION
We have had at least two issues where users missed the link to set the `cluster-store` parameter of the Docker daemon when using the Docker containerizer.

This change provides a small amount of duplication between the docker containerizer setup and the libnetwork docs, but it is worth it to provide a more streamlined experience with less errors.