### PR TITLE
Watch etcd for new ipip pools

### DIFF
--- a/calico_node/filesystem/allocate-ipip-addr.py
+++ b/calico_node/filesystem/allocate-ipip-addr.py
@@ -1,0 +1,29 @@
+# If IPIP is enabled, the host requires an IP address for its tunnel
+# device, which is in an IPIP pool.  Without this, a host can't originate
+# traffic to a pool address because the response traffic would not be
+# routed via the tunnel (likely being dropped by RPF checks in the fabric).
+#
+# This is a oneshot python script that queries etcd for existing pools.
+# If any pool has --ipip, it will ensure this host's tunl0 interface
+# has been assigned an IP from the ipip pool.
+
+import os
+from startup import _ensure_host_tunnel_addr, _remove_host_tunnel_addr
+from pycalico.ipam import IPAMClient
+
+def main():
+	ipv4_pools = client.get_ip_pools(4)
+	ipip_pools = [p for p in ipv4_pools if p.ipip]
+
+	if ipip_pools:
+	    # IPIP is enabled, make sure the host has an address for its tunnel.
+	    _ensure_host_tunnel_addr(ipv4_pools, ipip_pools)
+	else:
+	    # No IPIP pools, clean up any old address.
+	    _remove_host_tunnel_addr()
+
+hostname = os.getenv("HOSTNAME")
+client = IPAMClient()
+
+if __name__ == "__main__":
+    main()

--- a/calico_node/filesystem/etc/calico/confd/conf.d/tunl-ip.toml
+++ b/calico_node/filesystem/etc/calico/confd/conf.d/tunl-ip.toml
@@ -1,0 +1,8 @@
+[template]
+src = "tunl-ip.template"
+dest = "/tmp/tunl-ip"
+prefix = "/calico/v1/ipam/v4"
+keys = [
+    "/pool",
+]
+reload_cmd = "python /allocate-ipip-addr.py"

--- a/calico_node/filesystem/etc/calico/confd/templates/tunl-ip.template
+++ b/calico_node/filesystem/etc/calico/confd/templates/tunl-ip.template
@@ -1,0 +1,7 @@
+We must dump all pool data to this file to trigger a resync.
+Otherwise, confd notices the file hasn't changed and won't
+run our python update script.
+ 
+{{range ls "/pool"}}{{$data := json (getv (printf "/pool/%s" .))}}
+  {{if $data.ipip}}{{$data.cidr}}{{end}}
+{{end}}

--- a/tests/st/test_ipip.py
+++ b/tests/st/test_ipip.py
@@ -12,8 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from unittest import skip
+import re
 
+from netaddr import IPAddress, IPNetwork
 from test_base import TestBase
+from tests.st.utils.docker_host import DockerHost
+from time import sleep
+from tests.st.utils.utils import retry_until_success
 
 """
 Test calico IPIP behaviour
@@ -28,3 +33,60 @@ class TestIPIP(TestBase):
     @skip("Not written yet")
     def test_ipip(self):
         pass
+
+    def test_ipip_addr_assigned(self):
+        with DockerHost('host', dind=False, start_calico=False) as host:
+            # Set up first pool before Node is started, to ensure we get tunl IP on boot
+            ipv4_pool = IPNetwork("10.0.1.0/24")
+            host.calicoctl("pool add %s --ipip" % ipv4_pool)
+            host.start_calico_node()
+            self.assert_tunl_ip(host, ipv4_pool, expect=True)
+
+            # Test that removing tunl removes the tunl IP.
+            host.calicoctl("pool remove %s" % ipv4_pool)
+            self.assert_tunl_ip(host, ipv4_pool, expect=False)
+
+            # Test that re-adding the pool triggers the confd watch and we get an IP
+            host.calicoctl("pool add %s --ipip" % ipv4_pool)
+            self.assert_tunl_ip(host, ipv4_pool, expect=True)
+
+            # Test that by adding another pool, then deleting the first,
+            # we remove the original IP, and allocate a new one from the new pool
+            new_ipv4_pool = IPNetwork("192.168.0.0/16")
+            host.calicoctl("pool add %s --ipip" % new_ipv4_pool)
+            host.calicoctl("pool remove %s" % ipv4_pool)
+            self.assert_tunl_ip(host, new_ipv4_pool)
+
+
+    def assert_tunl_ip(self, host, ip_network, expect=True):
+        """
+        Helper function to make assertions on whether or not the tunl interface
+        on the Host has been assigned an IP or not. This function will retry
+        7 times, ensuring that our 5 second confd watch will trigger.
+
+        :param host: DockerHost object
+        :param ip_network: IPNetwork object which describes the ip-range we do (or do not)
+        expect to see an IP from on the tunl interface.
+        :param expect: Whether or not we are expecting to see an IP from IPNetwork on the tunl interface.
+        :return:
+        """
+        retries = 7
+        for retry in range(retries + 1):
+            try:
+                output = host.execute("ip addr show tunl0")
+                match = re.search(r'inet ([\d]{1,3}\.[\d]{1,3}\.[\d]{1,3}\.[\d]{1,3})', output)
+                if match:
+                    ip_address = IPAddress(match.group(1))
+                    if expect:
+                        self.assertIn(ip_address, ip_network)
+                    else:
+                        self.assertNotIn(ip_address, ip_network)
+                else:
+                    self.assertFalse(expect, "No IP address assigned to tunl interface.")
+            except Exception as e:
+                if retry < retries:
+                    sleep(1)
+                else:
+                    raise e
+            else:
+                return


### PR DESCRIPTION
Currently, Felix watches etcd and creates a tunl0 interface if a pool with `--ipip` was added. It also watches the host-specific setting `IpInIpTunnelAddr`  and assigns that address to the tunnel. 

However, `IpInIpTunnelAddr` is only set during invocation of `calicoctl node`. This means that if you add an `--ipip` pool without rerunning node on every Host, your host won't have allocated itself an IP, and your tunl interface won't be assigned one.

This PR uses confd to watch for changes in the ip pools, and allocates an `IpInIpTunnelAddr`  and assigns the address if a pool with `--ipip` is added.