### PR TITLE
Bumped ICMP validation test to use 256

### DIFF
--- a/calicoctl/tests/unit/profile_test.py
+++ b/calicoctl/tests/unit/profile_test.py
@@ -36,7 +36,7 @@ class TestProfile(unittest.TestCase):
         ({'<ICMPCODE>':'5'}, False),
         ({'<ICMPTYPE>':'16'}, False),
         ({'<ICMPCODE>':100, '<ICMPTYPE>':100}, False),
-        ({'<ICMPCODE>':4, '<ICMPTYPE>':255}, True),
+        ({'<ICMPCODE>':4, '<ICMPTYPE>':256}, True),
         ({'<SRCPORTS>':'6,9,10', '<DSTPORTS>':'66,88,95'}, False),
         ({'<SRCPORTS>':'6,9,-10', '<DSTPORTS>':'66,88,95'}, True),
         ({'<SRCPORTS>':'53:99', '<DSTPORTS>':'66,88,95'}, False),


### PR DESCRIPTION
Since we've increased the range of valid ICMP types to include 255 in [libcalico#117](https://github.com/projectcalico/libcalico/pull/117).