### PR TITLE
Remove version header from building.md

### DIFF
--- a/docs/Building.md
+++ b/docs/Building.md
@@ -1,11 +1,3 @@
-<!--- master only -->
-> ![warning](images/warning.png) This document applies to the HEAD of the calico-containers source tree.
->
-> View the calico-containers documentation for the latest release [here](https://github.com/projectcalico/calico-containers/blob/v0.13.0/README.md).
-<!--- else
-> You are viewing the calico-containers documentation for release **release**.
-<!--- end of master only -->
-
 # Building and testing calico-containers images
 
 This document describes how to build the `calicoctl` binary and the `calico/node` Docker image, and how to run the Calico Docker test suites.


### PR DESCRIPTION
It's about building from master so doesn't need a version header