### PR TITLE
Replace Metaswitch copyright statements with Tigera.

### DIFF
--- a/calico_node/Dockerfile
+++ b/calico_node/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2015 Metaswitch Networks
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/calico_node/filesystem/startup.py
+++ b/calico_node/filesystem/startup.py
@@ -1,5 +1,4 @@
 # Copyright (c) 2016 Tigera, Inc. All rights reserved.
-# Copyright 2016 Metaswitch Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/calico_node/filesystem/tests/startup_test.py
+++ b/calico_node/filesystem/tests/startup_test.py
@@ -1,5 +1,4 @@
-# Copyright (c) 2016 Tigera, Inc. All rights reserved.
-# Copyright 2015 Metaswitch Networks
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/calicoctl/calico_ctl/bgp.py
+++ b/calicoctl/calico_ctl/bgp.py
@@ -1,5 +1,4 @@
-# Copyright (c) 2016 Tigera, Inc. All rights reserved.
-# Copyright 2015 Metaswitch Networks
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/calicoctl/calico_ctl/checksystem.py
+++ b/calicoctl/calico_ctl/checksystem.py
@@ -1,5 +1,4 @@
-# Copyright (c) 2016 Tigera, Inc. All rights reserved.
-# Copyright 2015 Metaswitch Networks
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/calicoctl/calico_ctl/config.py
+++ b/calicoctl/calico_ctl/config.py
@@ -1,5 +1,4 @@
-# Copyright (c) 2016 Tigera, Inc. All rights reserved.
-# Copyright 2015 Metaswitch Networks
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/calicoctl/calico_ctl/connectors.py
+++ b/calicoctl/calico_ctl/connectors.py
@@ -1,5 +1,4 @@
-# Copyright (c) 2016 Tigera, Inc. All rights reserved.
-# Copyright 2015 Metaswitch Networks
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/calicoctl/calico_ctl/diags.py
+++ b/calicoctl/calico_ctl/diags.py
@@ -1,5 +1,4 @@
-# Copyright (c) 2016 Tigera, Inc. All rights reserved.
-# Copyright 2015 Metaswitch Networks
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/calicoctl/calico_ctl/endpoint.py
+++ b/calicoctl/calico_ctl/endpoint.py
@@ -1,5 +1,4 @@
-# Copyright (c) 2016 Tigera, Inc. All rights reserved.
-# Copyright 2015 Metaswitch Networks
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/calicoctl/calico_ctl/ipam.py
+++ b/calicoctl/calico_ctl/ipam.py
@@ -1,5 +1,4 @@
-# Copyright (c) 2016 Tigera, Inc. All rights reserved.
-# Copyright 2015 Metaswitch Networks
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/calicoctl/calico_ctl/node.py
+++ b/calicoctl/calico_ctl/node.py
@@ -1,5 +1,4 @@
-# Copyright (c) 2016 Tigera, Inc. All rights reserved.
-# Copyright 2015 Metaswitch Networks
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/calicoctl/calico_ctl/pool.py
+++ b/calicoctl/calico_ctl/pool.py
@@ -1,5 +1,4 @@
-# Copyright (c) 2016 Tigera, Inc. All rights reserved.
-# Copyright 2015 Metaswitch Networks
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/calicoctl/calico_ctl/profile.py
+++ b/calicoctl/calico_ctl/profile.py
@@ -1,5 +1,4 @@
-# Copyright (c) 2016 Tigera, Inc. All rights reserved.
-# Copyright 2015 Metaswitch Networks
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/calicoctl/calico_ctl/status.py
+++ b/calicoctl/calico_ctl/status.py
@@ -1,5 +1,4 @@
-# Copyright (c) 2016 Tigera, Inc. All rights reserved.
-# Copyright 2015 Metaswitch Networks
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/calicoctl/calico_ctl/utils.py
+++ b/calicoctl/calico_ctl/utils.py
@@ -1,5 +1,4 @@
-# Copyright (c) 2016 Tigera, Inc. All rights reserved.
-# Copyright 2015 Metaswitch Networks
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/calicoctl/calico_ctl/version.py
+++ b/calicoctl/calico_ctl/version.py
@@ -1,5 +1,4 @@
-# Copyright (c) 2016 Tigera, Inc. All rights reserved.
-# Copyright 2015 Metaswitch Networks
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/calicoctl/calicoctl.py
+++ b/calicoctl/calicoctl.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2016 Tigera, Inc. All rights reserved.
-# Copyright 2015 Metaswitch Networks
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/calicoctl/tests/unit/bgp_test.py
+++ b/calicoctl/tests/unit/bgp_test.py
@@ -1,5 +1,4 @@
-# Copyright (c) 2016 Tigera, Inc. All rights reserved.
-# Copyright 2015 Metaswitch Networks
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/calicoctl/tests/unit/checksystem_test.py
+++ b/calicoctl/tests/unit/checksystem_test.py
@@ -1,5 +1,4 @@
-# Copyright (c) 2016 Tigera, Inc. All rights reserved.
-# Copyright 2015 Metaswitch Networks
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/calicoctl/tests/unit/container_test.py
+++ b/calicoctl/tests/unit/container_test.py
@@ -1,5 +1,4 @@
-# Copyright (c) 2016 Tigera, Inc. All rights reserved.
-# Copyright 2015 Metaswitch Networks
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/calicoctl/tests/unit/endpoint_test.py
+++ b/calicoctl/tests/unit/endpoint_test.py
@@ -1,5 +1,4 @@
-# Copyright (c) 2016 Tigera, Inc. All rights reserved.
-# Copyright 2015 Metaswitch Networks
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/calicoctl/tests/unit/node_test.py
+++ b/calicoctl/tests/unit/node_test.py
@@ -1,5 +1,4 @@
-# Copyright (c) 2016 Tigera, Inc. All rights reserved.
-# Copyright 2015 Metaswitch Networks
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/calicoctl/tests/unit/pool_test.py
+++ b/calicoctl/tests/unit/pool_test.py
@@ -1,5 +1,4 @@
-# Copyright (c) 2016 Tigera, Inc. All rights reserved.
-# Copyright 2015 Metaswitch Networks
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/calicoctl/tests/unit/profile_test.py
+++ b/calicoctl/tests/unit/profile_test.py
@@ -1,5 +1,4 @@
-# Copyright (c) 2016 Tigera, Inc. All rights reserved.
-# Copyright 2015 Metaswitch Networks
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/calicoctl/tests/unit/utils_test.py
+++ b/calicoctl/tests/unit/utils_test.py
@@ -1,5 +1,4 @@
-# Copyright (c) 2016 Tigera, Inc. All rights reserved.
-# Copyright 2015 Metaswitch Networks
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/st/bgp/test_bgp_config.py
+++ b/tests/st/bgp/test_bgp_config.py
@@ -1,5 +1,4 @@
-# Copyright (c) 2016 Tigera, Inc. All rights reserved.
-# Copyright 2015 Metaswitch Networks
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/st/bgp/test_global_peers.py
+++ b/tests/st/bgp/test_global_peers.py
@@ -1,5 +1,4 @@
-# Copyright (c) 2016 Tigera, Inc. All rights reserved.
-# Copyright 2015 Metaswitch Networks
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/st/bgp/test_node_peers.py
+++ b/tests/st/bgp/test_node_peers.py
@@ -1,5 +1,4 @@
-# Copyright (c) 2016 Tigera, Inc. All rights reserved.
-# Copyright 2015 Metaswitch Networks
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/st/bgp/test_route_reflector_cluster.py
+++ b/tests/st/bgp/test_route_reflector_cluster.py
@@ -1,5 +1,4 @@
-# Copyright (c) 2016 Tigera, Inc. All rights reserved.
-# Copyright 2015 Metaswitch Networks
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/st/bgp/test_single_route_reflector.py
+++ b/tests/st/bgp/test_single_route_reflector.py
@@ -1,5 +1,4 @@
-# Copyright (c) 2016 Tigera, Inc. All rights reserved.
-# Copyright 2015 Metaswitch Networks
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/st/no_orchestrator/test_add_autoassigned_ip.py
+++ b/tests/st/no_orchestrator/test_add_autoassigned_ip.py
@@ -1,5 +1,4 @@
-# Copyright (c) 2016 Tigera, Inc. All rights reserved.
-# Copyright 2015 Metaswitch Networks
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/st/no_orchestrator/test_add_ip.py
+++ b/tests/st/no_orchestrator/test_add_ip.py
@@ -1,5 +1,4 @@
-# Copyright (c) 2016 Tigera, Inc. All rights reserved.
-# Copyright 2015 Metaswitch Networks
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/st/no_orchestrator/test_container_to_host.py
+++ b/tests/st/no_orchestrator/test_container_to_host.py
@@ -1,5 +1,4 @@
-# Copyright (c) 2016 Tigera, Inc. All rights reserved.
-# Copyright 2015 Metaswitch Networks
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/st/no_orchestrator/test_interfaces.py
+++ b/tests/st/no_orchestrator/test_interfaces.py
@@ -1,5 +1,4 @@
-# Copyright (c) 2016 Tigera, Inc. All rights reserved.
-# Copyright 2015 Metaswitch Networks
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/st/no_orchestrator/test_mainline_multi_host.py
+++ b/tests/st/no_orchestrator/test_mainline_multi_host.py
@@ -1,5 +1,4 @@
-# Copyright (c) 2016 Tigera, Inc. All rights reserved.
-# Copyright 2015 Metaswitch Networks
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/st/no_orchestrator/test_mainline_single_host.py
+++ b/tests/st/no_orchestrator/test_mainline_single_host.py
@@ -1,5 +1,4 @@
-# Copyright (c) 2016 Tigera, Inc. All rights reserved.
-# Copyright 2015 Metaswitch Networks
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/st/no_orchestrator/test_manage_pools.py
+++ b/tests/st/no_orchestrator/test_manage_pools.py
@@ -1,5 +1,4 @@
-# Copyright (c) 2016 Tigera, Inc. All rights reserved.
-# Copyright 2015 Metaswitch Networks
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/st/test_checksystem.py
+++ b/tests/st/test_checksystem.py
@@ -1,5 +1,4 @@
-# Copyright (c) 2016 Tigera, Inc. All rights reserved.
-# Copyright 2015 Metaswitch Networks
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/st/test_diags.py
+++ b/tests/st/test_diags.py
@@ -1,5 +1,4 @@
-# Copyright (c) 2016 Tigera, Inc. All rights reserved.
-# Copyright 2015 Metaswitch Networks
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/st/test_endpoint.py
+++ b/tests/st/test_endpoint.py
@@ -1,5 +1,4 @@
-# Copyright (c) 2016 Tigera, Inc. All rights reserved.
-# Copyright 2015 Metaswitch Networks
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/st/test_ipip.py
+++ b/tests/st/test_ipip.py
@@ -1,5 +1,4 @@
-# Copyright (c) 2016 Tigera, Inc. All rights reserved.
-# Copyright 2015 Metaswitch Networks
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/st/test_node.py
+++ b/tests/st/test_node.py
@@ -1,5 +1,4 @@
-# Copyright (c) 2016 Tigera, Inc. All rights reserved.
-# Copyright 2015 Metaswitch Networks
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/st/test_pool.py
+++ b/tests/st/test_pool.py
@@ -1,5 +1,4 @@
-# Copyright (c) 2016 Tigera, Inc. All rights reserved.
-# Copyright 2015 Metaswitch Networks
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/st/test_profile.py
+++ b/tests/st/test_profile.py
@@ -1,5 +1,4 @@
-# Copyright (c) 2016 Tigera, Inc. All rights reserved.
-# Copyright 2015 Metaswitch Networks
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/st/test_status.py
+++ b/tests/st/test_status.py
@@ -1,5 +1,4 @@
-# Copyright (c) 2016 Tigera, Inc. All rights reserved.
-# Copyright 2015 Metaswitch Networks
+# Copyright (c) 2015-2016 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
According to the lawyers, we need to update the existing copyrights too.