### PR TITLE
Pinned alpine to fix setuptools issue.

### DIFF
--- a/calico_node/Dockerfile
+++ b/calico_node/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gliderlabs/alpine:edge
+FROM gliderlabs/alpine:3.4
 MAINTAINER Tom Denham <tom@projectcalico.org>
 
 ENV GLIBC_VERSION 2.23-r1
@@ -29,7 +29,7 @@ RUN apk add --update curl && \
   rm -rf /var/cache/apk/*
 
 ADD build.sh /build.sh
-RUN /build.sh # 23MAR2016
+RUN /build.sh
 
 # Copy in our custom configuration files etc. We do this last to speed up
 # builds for developer, as it's the thing they're most likely to change.

--- a/calico_node/build.sh
+++ b/calico_node/build.sh
@@ -16,13 +16,14 @@
 set -e
 set -x
 
-# Ensure the main and testing repros are present. Needed for runit
-echo "http://alpine.gliderlabs.com/alpine/edge/testing" >> /etc/apk/repositories
-
 # These packages make it into the final image.
-apk -U add runit python py-setuptools libffi ip6tables ipset iputils iproute2 yajl conntrack-tools
+# Install runit from the testing repository, as its not yet available in global
+apk add --update-cache --repository "http://alpine.gliderlabs.com/alpine/edge/testing" runit
+# Install remaining runtime deps from the global repository
+apk add --update-cache python py-setuptools libffi ip6tables ipset iputils iproute2 yajl conntrack-tools
 
-# These packages are only used for building and get removed.
+# Add these build-tools packages under a virtual package named 'temp' which 
+# will be uninstalled post-build.
 apk add --virtual temp python-dev libffi-dev py-pip alpine-sdk curl
 
 # Install Confd


### PR DESCRIPTION
This PR temporarily fixes the build by pinning the alpine image calico-node is built from to 3.3. 

See #1040 for more information on what may be causing failures.