### PR TITLE
Update stars demo files and kubedns

### DIFF
--- a/docs/cni/kubernetes/manifests/skydns.yaml
+++ b/docs/cni/kubernetes/manifests/skydns.yaml
@@ -18,80 +18,86 @@ spec:
   - name: dns-tcp
     port: 53
     protocol: TCP
-
 ---
 
 apiVersion: v1
 kind: ReplicationController
 metadata:
-  name: kube-dns-v9
+  name: kube-dns-v18
   namespace: kube-system
   labels:
     k8s-app: kube-dns
-    version: v9
+    version: v18
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: 1
   selector:
     k8s-app: kube-dns
-    version: v9
+    version: v18
   template:
     metadata:
       labels:
         k8s-app: kube-dns
-        version: v9
+        version: v18
         kubernetes.io/cluster-service: "true"
     spec:
+      volumes:
+      # Configures DNS to communicate with the master. 
+      # Relies on a kubeconfig file on the worker.
+      - name: "worker-kubeconfig"
+        hostPath:
+          path: "/etc/kubernetes/worker-kubeconfig.yaml"
       containers:
-      - name: etcd
-        image: gcr.io/google_containers/etcd:2.2.1
+      - name: kubedns
+        image: gcr.io/google_containers/kubedns-amd64:1.6
         resources:
           limits:
             cpu: 100m
-            memory: 50Mi
-        command:
-        - /usr/local/bin/etcd
-        - -data-dir
-        - /var/etcd/data
-        - -listen-client-urls
-        - http://127.0.0.1:2379,http://127.0.0.1:4001
-        - -advertise-client-urls
-        - http://127.0.0.1:2379,http://127.0.0.1:4001
-        - -initial-cluster-token
-        - skydns-etcd
-        volumeMounts:
-        - name: etcd-storage
-          mountPath: /var/etcd/data
-      - name: kube2sky
-        image: gcr.io/google_containers/kube2sky:1.11
-        resources:
-          limits:
+            memory: 200Mi
+          requests:
             cpu: 100m
-            memory: 50Mi
+            memory: 100Mi
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: 8081
+            scheme: HTTP
+          # we poll on pod startup for the Kubernetes master service and
+          # only setup the /readiness HTTP server once that's available.
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
         args:
-        # command = "/kube2sky"
-        - -domain=cluster.local
-        - -kubecfg_file=/etc/kubernetes/worker-kubeconfig.yaml
+        # command = "/kube-dns"
+        - --domain=cluster.local
+        - --dns-port=10053
+        - --kubecfg-file=/etc/kubernetes/worker-kubeconfig.yaml
         volumeMounts:
         - mountPath: /etc/ssl/certs
           name: "ssl-certs"
-        - mountPath: /etc/kubernetes/worker-kubeconfig.yaml
+          mountPath: /etc/kubernetes/worker-kubeconfig.yaml
           name: "worker-kubeconfig"
-          readOnly: true
-        - mountPath: /etc/kubernetes/ssl
-          name: "etc-kube-ssl"
-          readOnly: true
-      - name: skydns
-        image: gcr.io/google_containers/skydns:2015-10-13-8c72f8c
-        resources:
-          limits:
-            cpu: 100m
-            memory: 50Mi
+        ports:
+        - containerPort: 10053
+          name: dns-local
+          protocol: UDP
+        - containerPort: 10053
+          name: dns-tcp-local
+          protocol: TCP
+      - name: dnsmasq
+        image: gcr.io/google_containers/kube-dnsmasq-amd64:1.3
         args:
-        # command = "/skydns"
-        - -machines=http://localhost:4001
-        - -addr=0.0.0.0:53
-        - -domain=cluster.local.
+        - --cache-size=1000
+        - --no-resolv
+        - --server=127.0.0.1#10053
         ports:
         - containerPort: 53
           name: dns
@@ -99,42 +105,21 @@ spec:
         - containerPort: 53
           name: dns-tcp
           protocol: TCP
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8080
-            scheme: HTTP
-          initialDelaySeconds: 30
-          timeoutSeconds: 5
-        readinessProbe:
-          httpGet:
-            path: /healthz
-            port: 8080
-            scheme: HTTP
-          initialDelaySeconds: 1
-          timeoutSeconds: 5
       - name: healthz
-        image: gcr.io/google_containers/exechealthz:1.0
+        image: gcr.io/google_containers/exechealthz-amd64:1.0
         resources:
+          # keep request = limit to keep this container in guaranteed class
           limits:
             cpu: 10m
             memory: 20Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi
         args:
-        - -cmd=nslookup kubernetes.default.svc.cluster.local localhost >/dev/null
+        - -cmd=nslookup kubernetes.default.svc.cluster.local 127.0.0.1 >/dev/null && nslookup kubernetes.default.svc.cluster.local 127.0.0.1:10053 >/dev/null
         - -port=8080
+        - -quiet
         ports:
         - containerPort: 8080
           protocol: TCP
-      volumes:
-      - name: etcd-storage
-        emptyDir: {}
-      - name: "ssl-certs"
-        hostPath:
-          path: "/usr/share/ca-certificates"
-      - name: "worker-kubeconfig"
-        hostPath:
-          path: "/etc/kubernetes/worker-kubeconfig.yaml"
-      - name: "etc-kube-ssl"
-        hostPath:
-          path: "/etc/kubernetes/ssl"
       dnsPolicy: Default  # Don't use cluster DNS.

--- a/docs/cni/kubernetes/stars-demo/manifests/backend.yaml
+++ b/docs/cni/kubernetes/stars-demo/manifests/backend.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - name: backend 
-        image: caseydavenport/probe:calico-containers-demo
+        image: calico/star-probe:v0.1.0
         imagePullPolicy: Always
         command:
         - probe

--- a/docs/cni/kubernetes/stars-demo/manifests/backend.yaml
+++ b/docs/cni/kubernetes/stars-demo/manifests/backend.yaml
@@ -29,6 +29,6 @@ spec:
         command:
         - probe
         - --http-port=6379
-        - --urls=http://frontend.stars.cluster.local:80/status,http://backend.stars.cluster.local:6379/status,http://client.client.cluster.local:9000/status
+        - --urls=http://frontend.stars:80/status,http://backend.stars:6379/status,http://client.client:9000/status
         ports:
         - containerPort: 6379 

--- a/docs/cni/kubernetes/stars-demo/manifests/client.yaml
+++ b/docs/cni/kubernetes/stars-demo/manifests/client.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: client 
-        image: caseydavenport/probe:calico-containers-demo
+        image: calico/star-probe:v0.1.0
         imagePullPolicy: Always
         command:
         - probe

--- a/docs/cni/kubernetes/stars-demo/manifests/client.yaml
+++ b/docs/cni/kubernetes/stars-demo/manifests/client.yaml
@@ -23,7 +23,7 @@ spec:
         imagePullPolicy: Always
         command:
         - probe
-        - --urls=http://frontend.stars.cluster.local:80/status,http://backend.stars.cluster.local:6379/status
+        - --urls=http://frontend.stars:80/status,http://backend.stars:6379/status
         ports:
         - containerPort: 9000 
 ---

--- a/docs/cni/kubernetes/stars-demo/manifests/frontend.yaml
+++ b/docs/cni/kubernetes/stars-demo/manifests/frontend.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - name: frontend 
-        image: caseydavenport/probe:calico-containers-demo
+        image: calico/star-probe:v0.1.0
         imagePullPolicy: Always
         command:
         - probe

--- a/docs/cni/kubernetes/stars-demo/manifests/frontend.yaml
+++ b/docs/cni/kubernetes/stars-demo/manifests/frontend.yaml
@@ -29,6 +29,6 @@ spec:
         command:
         - probe
         - --http-port=80
-        - --urls=http://frontend.stars.cluster.local:80/status,http://backend.stars.cluster.local:6379/status,http://client.client.cluster.local:9000/status
+        - --urls=http://frontend.stars:80/status,http://backend.stars:6379/status,http://client.client:9000/status
         ports:
         - containerPort: 80 

--- a/docs/cni/kubernetes/stars-demo/manifests/management-ui.yaml
+++ b/docs/cni/kubernetes/stars-demo/manifests/management-ui.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: management-ui 
-        image: caseydavenport/collect:calico-containers-demo
+        image: caseydavenport/collect:v0.1.0
         imagePullPolicy: Always
         ports:
         - containerPort: 9001

--- a/docs/cni/kubernetes/stars-demo/manifests/management-ui.yaml
+++ b/docs/cni/kubernetes/stars-demo/manifests/management-ui.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: management-ui 
-        image: caseydavenport/collect:v0.1.0
+        image: calico/star-collect:v0.1.0
         imagePullPolicy: Always
         ports:
         - containerPort: 9001

--- a/docs/cni/kubernetes/vagrant-coreos/Vagrantfile
+++ b/docs/cni/kubernetes/vagrant-coreos/Vagrantfile
@@ -52,8 +52,8 @@ Vagrant.configure("2") do |config|
         # Configure a node.
 	host.vm.provision :docker, images: ["busybox:latest", 
                                             "gcr.io/google_containers/pause:0.8.0",
-                                            "caseydavenport/collect:calico-containers-demo",
-                                            "caseydavenport/probe:calico-containers-demo"] 
+                                            "calico/star-collect:v0.1.0",
+                                            "calico/star-probe:v0.1.0"] 
         host.vm.provision :file, :source => "cloud-config/node-config.yaml", :destination => "/tmp/vagrantfile-user-data"
         host.vm.provision :shell, :inline => "mv /tmp/vagrantfile-user-data /var/lib/coreos-vagrant/", :privileged => true
       end


### PR DESCRIPTION
The DNS manifest is used across the AWS, GCE, and Vagrant demos.  I've also checked that the stars demo works on each.

- Updates to latest kubedns
- Updates stars demo manifests to use correct domain names.
- Updates to use `calico/` versions of the stars Docker images rather than `caseydavenport/`