### PR TITLE
Provisioning /etc/hosts with localhost

### DIFF
--- a/docs/cni/kubernetes/vagrant-coreos/Vagrantfile
+++ b/docs/cni/kubernetes/vagrant-coreos/Vagrantfile
@@ -43,6 +43,7 @@ Vagrant.configure("2") do |config|
         host.vm.provision :file, :source => "../manifests/guestbook.yaml", :destination => "/home/core/guestbook.yaml"
         host.vm.provision :file, :source => "cloud-config/master-config.yaml", :destination => "/tmp/vagrantfile-user-data"
         host.vm.provision :file, :source => "manifests/policy-controller.yaml", :destination => "/tmp/policy-controller.yaml"
+        host.vm.provision :shell, :inline => "echo '127.0.0.1\tlocalhost' > /etc/hosts", :privileged => true
         host.vm.provision :shell, :inline => "mkdir -p /etc/kubernetes/manifests/", :privileged => true
         host.vm.provision :shell, :inline => "mv /tmp/policy-controller.yaml /etc/kubernetes/manifests/", :privileged => true
 


### PR DESCRIPTION
The lack of localhost in /etc/hosts caused problems with kubectl

Fixes #1045