### PR TITLE
Ensure versions are correct when doing releases

### DIFF
--- a/release-scripts/do_release.py
+++ b/release-scripts/do_release.py
@@ -265,6 +265,7 @@ def cut_release():
            "(e.g. git checkout tags/%s):" % new_version)
     bullet("CoreOS libnetwork", level=1)
     bullet("Ubuntu default networking", level=1)
+    bullet("Make sure to check the reported versions of all artifacts.")
     next("Once you have completed the testing, re-run the script.")
 
 


### PR DESCRIPTION
Avoid repeats of #1073.  The release scripts looked right to me, there's manual steps involved, and 0.19 was right (and used the same scripts).

I think it's a one-off, so just adding a note to make sure :).