### PR TITLE
Fix calico-mesos-docker demo

### DIFF
--- a/docs/mesos/vagrant-centos/units/docker.service.d/docker.conf
+++ b/docs/mesos/vagrant-centos/units/docker.service.d/docker.conf
@@ -1,4 +1,4 @@
 [Service]
 EnvironmentFile=/etc/sysconfig/calico
 ExecStart=
-ExecStart=/usr/bin/docker daemon -H fd:// --cluster-store=etcd://${ETCD_AUTHORITY}
+ExecStart=/usr/bin/dockerd --cluster-store=etcd://${ETCD_AUTHORITY}


### PR DESCRIPTION
Fixed the docker systemd dropin as v1.12.0 of docker doesn't need fd:// in centos (apparently).

A better fix would be to change this so instead of using a systemd dropin, we set `daemon.json`...