### PR TITLE
Add -c flag to wget to continue downloading

### DIFF
--- a/docs/cni/kubernetes/vagrant-coreos/cloud-config/master-config.yaml
+++ b/docs/cni/kubernetes/vagrant-coreos/cloud-config/master-config.yaml
@@ -29,8 +29,8 @@ coreos:
         Requires=etcd2.service
         After=etcd2.service
         [Service]
-        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v1.3.0/bin/linux/amd64/kubectl
-        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v1.3.0/bin/linux/amd64/kube-apiserver
+        ExecStartPre=/usr/bin/wget -c -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v1.3.0/bin/linux/amd64/kubectl
+        ExecStartPre=/usr/bin/wget -c -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v1.3.0/bin/linux/amd64/kube-apiserver
         ExecStartPre=/usr/bin/chmod +x /opt/bin/kubectl
         ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-apiserver
         ExecStart=/opt/bin/kube-apiserver \
@@ -53,7 +53,7 @@ coreos:
         Requires=kube-apiserver.service
         After=kube-apiserver.service
         [Service]
-        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v1.3.0/bin/linux/amd64/kube-controller-manager
+        ExecStartPre=/usr/bin/wget -c -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v1.3.0/bin/linux/amd64/kube-controller-manager
         ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-controller-manager
         ExecStart=/opt/bin/kube-controller-manager \
         --master=$private_ipv4:8080 \
@@ -70,7 +70,7 @@ coreos:
         Requires=kube-apiserver.service
         After=kube-apiserver.service
         [Service]
-        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v1.3.0/bin/linux/amd64/kube-scheduler
+        ExecStartPre=/usr/bin/wget -c -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v1.3.0/bin/linux/amd64/kube-scheduler
         ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-scheduler
         ExecStart=/opt/bin/kube-scheduler --master=$private_ipv4:8080
         Restart=always
@@ -89,7 +89,7 @@ coreos:
         User=root
         Environment="ETCD_AUTHORITY=localhost:2379"
         PermissionsStartOnly=true
-        ExecStartPre=/usr/bin/wget -O /opt/bin/calicoctl https://github.com/projectcalico/calico-containers/releases/download/v0.21.0/calicoctl
+        ExecStartPre=/usr/bin/wget -c -O /opt/bin/calicoctl https://github.com/projectcalico/calico-containers/releases/download/v0.21.0/calicoctl
         ExecStartPre=/usr/bin/chmod +x /opt/bin/calicoctl
         ExecStartPre=/opt/bin/calicoctl pool add 192.168.0.0/16 --nat-outgoing
         ExecStart=/opt/bin/calicoctl node --ip=$private_ipv4 --detach=false --node-image=calico/node:v0.21.0
@@ -110,7 +110,7 @@ coreos:
         Requires=docker.service
 
         [Service]
-        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v1.3.0/bin/linux/amd64/kubelet
+        ExecStartPre=/usr/bin/wget -c -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v1.3.0/bin/linux/amd64/kubelet
         ExecStartPre=/usr/bin/chmod +x /opt/bin/kubelet
         ExecStart=/opt/bin/kubelet \
         --address=0.0.0.0 \
@@ -138,7 +138,7 @@ coreos:
         Requires=kubelet.service
         After=kubelet.service
         [Service]
-        ExecStartPre=/usr/bin/wget -N -P /opt/bin  https://storage.googleapis.com/kubernetes-release/release/v1.3.0/bin/linux/amd64/kube-proxy
+        ExecStartPre=/usr/bin/wget -c -N -P /opt/bin  https://storage.googleapis.com/kubernetes-release/release/v1.3.0/bin/linux/amd64/kube-proxy
         ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-proxy
         ExecStart=/opt/bin/kube-proxy \
         --master=http://$private_ipv4:8080 \

--- a/docs/cni/kubernetes/vagrant-coreos/cloud-config/node-config.yaml
+++ b/docs/cni/kubernetes/vagrant-coreos/cloud-config/node-config.yaml
@@ -88,7 +88,7 @@ coreos:
         Requires=docker.service
 
         [Service]
-        ExecStartPre=/usr/bin/wget -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v1.3.0/bin/linux/amd64/kubelet
+        ExecStartPre=/usr/bin/wget -c -N -P /opt/bin https://storage.googleapis.com/kubernetes-release/release/v1.3.0/bin/linux/amd64/kubelet
         ExecStartPre=/usr/bin/chmod +x /opt/bin/kubelet
         ExecStartPre=/usr/bin/mkdir -p /opt/cni/bin
         ExecStartPre=/usr/bin/wget -O /opt/cni/bin/calico https://github.com/projectcalico/calico-cni/releases/download/v1.3.0/calico 
@@ -119,7 +119,7 @@ coreos:
         Requires=kubelet.service
         After=kubelet.service
         [Service]
-        ExecStartPre=/usr/bin/wget -N -P /opt/bin  https://storage.googleapis.com/kubernetes-release/release/v1.3.0/bin/linux/amd64/kube-proxy
+        ExecStartPre=/usr/bin/wget -c -N -P /opt/bin  https://storage.googleapis.com/kubernetes-release/release/v1.3.0/bin/linux/amd64/kube-proxy
         ExecStartPre=/usr/bin/chmod +x /opt/bin/kube-proxy
         ExecStart=/opt/bin/kube-proxy \
         --master=http://172.18.18.101:8080 \


### PR DESCRIPTION
While setting up the cluster I had some download timeout or break in process and had to redownload all the files from storage.googleapis.com by hand.
This patch would save time and check if files have been downloaded completely.