### PR TITLE
Map HOSTNAME to FELIX_FELIXHOSTNAME in calico-node.

### DIFF
--- a/calico_node/filesystem/etc/service/felix/run
+++ b/calico_node/filesystem/etc/service/felix/run
@@ -1,5 +1,10 @@
 #!/bin/sh
 exec 2>&1
+# Felix doesn't understand HOSTNAME, but the container exports it as a common
+# interface. This ensures Felix gets the right hostname.
+if [ ! -z $HOSTNAME ]; then
+    export FELIX_FELIXHOSTNAME=$HOSTNAME
+fi
 export FELIX_ETCDADDR=$ETCD_AUTHORITY
 export FELIX_ETCDENDPOINTS=$ETCD_ENDPOINTS
 export FELIX_ETCDSCHEME=$ETCD_SCHEME


### PR DESCRIPTION
Setting `-e HOSTNAME` on the calico-container did not update the hostname
Felix receives, which leads to surprise breakages (blackhole routes work, but
interface routes don't).

Closes #1105

Note: this is untested just yet. I'm wondering if adding automated container integration tests is possible?