### PR TITLE
Adding Ubuntu 16.04 vagrant box

### DIFF
--- a/docs/calico-with-docker/VagrantUbuntu.md
+++ b/docs/calico-with-docker/VagrantUbuntu.md
@@ -8,15 +8,15 @@
 
 # Running the Calico tutorials on Ubuntu using Vagrant and VirtualBox
 
-These instructions allow you to set up an Ubuntu cluster ready to network Docker containers with 
+These instructions allow you to set up an Ubuntu cluster ready to network Docker containers with
 [Calico Docker networking][calico-networking] using Vagrant.
 
 ## 1. Streamlined setup of the VMs
 
 ### 1.1 Install dependencies
 
-* [VirtualBox][virtualbox] 5.0.0 or greater.
-* [Vagrant][vagrant] 1.7.4 or greater.
+* [VirtualBox][virtualbox] 5.0.22 or greater.
+* [Vagrant][vagrant] 1.8.4 or greater.
 * [Git][git]
 
 <!--- master only -->
@@ -29,7 +29,7 @@ These instructions allow you to set up an Ubuntu cluster ready to network Docker
     git clone https://github.com/projectcalico/calico-containers.git
     git checkout tags/**release**
 <!--- end of master only -->
-    
+
 ### 1.3 Startup and SSH
 
 There are two worked examples you can follow: Calico as a Docker network
@@ -37,13 +37,13 @@ plugin, or Calico without Docker networking.  Select the networking option
 by changing into the appropriate directory.
 
 For Calico as a Docker network plugin
-  
+
     cd calico-containers/docs/calico-with-docker/docker-network-plugin/vagrant-ubuntu
 
 For Calico without Docker networking
-  
+
     cd calico-containers/docs/calico-with-docker/without-docker-networking/vagrant-ubuntu
-        
+
 Use vagrant to create and boot your VMs.
 
     vagrant up
@@ -69,8 +69,8 @@ From calico-2
 
     ping 172.17.8.101
 
-If you see ping failures, the likely culprit is a problem with the VirtualBox network between the VMs.  You should 
-check that each host is connected to the same virtual network adapter in VirtualBox and rebooting the host may also 
+If you see ping failures, the likely culprit is a problem with the VirtualBox network between the VMs.  You should
+check that each host is connected to the same virtual network adapter in VirtualBox and rebooting the host may also
 help.  Remember to shut down the VMs with `vagrant halt` before you reboot.
 
 You should also verify each host can access etcd.  The following will return an error if etcd is not available.
@@ -86,10 +86,10 @@ And finally check that Docker is running on both hosts by running
 Now you have a basic two node Ubuntu cluster setup and you are ready to try Calico networking.
 
 There are two worked examples you can follow: Calico as a Docker network
-plugin, or Calico without Docker networking.  Select the instructions based on 
+plugin, or Calico without Docker networking.  Select the instructions based on
 the networking option that you chose in step (1.3).
 
-- [Calico as a Docker network plugin walkthrough](docker-network-plugin/README.md) 
+- [Calico as a Docker network plugin walkthrough](docker-network-plugin/README.md)
 - [Calico without Docker networking walkthrough](without-docker-networking/README.md)  
 
 [libnetwork]: https://github.com/docker/libnetwork

--- a/docs/calico-with-docker/docker-network-plugin/vagrant-ubuntu/Vagrantfile
+++ b/docs/calico-with-docker/docker-network-plugin/vagrant-ubuntu/Vagrantfile
@@ -24,10 +24,12 @@ primary_ip = "172.17.8.101"
 
 Vagrant.configure(2) do |config|
   # always use Vagrants insecure key
-  config.ssh.insert_key = false
+  config.ssh.insert_key = true
+  config.ssh.username = "vagrant"
 
-  # Use an official Ubuntu base box
-  config.vm.box = "ubuntu/trusty64"
+  # Use Bento Ubuntu 16.04 box (officially-recommended box by Vagrant)
+  # https://www.vagrantup.com/docs/boxes.html
+  config.vm.box = "bento/ubuntu-16.04"
 
   # Set up each box
   (1..num_instances).each do |i|
@@ -62,9 +64,11 @@ Vagrant.configure(2) do |config|
         SHELL
       end
 
-      # Set Docker to use etcd for multihost, then send SIGHUP to Docker process to restart.
-      host.vm.provision :shell, inline: %Q|sudo sh -c 'echo "DOCKER_OPTS=\"--cluster-store=etcd://#{primary_ip}:2379\"" > /etc/default/docker'|
-      host.vm.provision :shell, inline: "restart docker"
+      # Set Docker to use etcd for multihost, then reload systemctl and restart Docker.
+      host.vm.provision :shell, inline: "mkdir -p /etc/systemd/system/docker.service.d/"
+      host.vm.provision :shell, inline: %Q|sudo sh -c 'printf "[Service]\nExecStart=\nExecStart=/usr/bin/dockerd -H fd:// --cluster-store=etcd://#{primary_ip}:2379" > /etc/systemd/system/docker.service.d/10-execstart.conf'|
+      host.vm.provision :shell, inline: "systemctl daemon-reload"
+      host.vm.provision :shell, inline: "systemctl restart docker.service"
 
       # download calicoctl.
       host.vm.provision :shell, inline: "wget -qO /usr/local/bin/calicoctl #{calicoctl_url}", :privileged => true


### PR DESCRIPTION
Technology has moved on since Ubuntu 14.04 so that more and more people want to test Calico on Ubuntu 16.04.

Note, this Vagrantfile uses the `bento/ubuntu-16.04` box since the `ubuntu/xenial64` box is unusable unless it is customised. The Bento vagrant boxes are officially recommended by Hashicorp.
[https://www.vagrantup.com/docs/boxes.html](https://www.vagrantup.com/docs/boxes.html).