### PR TITLE
adjustments to improve the tutorial experience

### DIFF
--- a/docs/calico-with-docker/docker-network-plugin/vagrant-coreos/Vagrantfile
+++ b/docs/calico-with-docker/docker-network-plugin/vagrant-coreos/Vagrantfile
@@ -20,14 +20,14 @@ num_instances=2
 instance_name_prefix="calico"
 
 # Official CoreOS channel from which updates should be downloaded
-update_channel='alpha'
+update_channel='stable'
 
 Vagrant.configure("2") do |config|
   # always use Vagrants insecure key
   config.ssh.insert_key = false
 
   config.vm.box = "coreos-%s" % update_channel
-  config.vm.box_version = ">= 962.0.0"
+  config.vm.box_version = ">= 1122.0.0"
   config.vm.box_url = "http://%s.release.core-os.net/amd64-usr/current/coreos_production_vagrant.json" % update_channel
 
   config.vm.provider :virtualbox do |v|

--- a/docs/calico-with-docker/docker-network-plugin/vagrant-ubuntu/Vagrantfile
+++ b/docs/calico-with-docker/docker-network-plugin/vagrant-ubuntu/Vagrantfile
@@ -71,7 +71,7 @@ Vagrant.configure(2) do |config|
       host.vm.provision :shell, inline: "systemctl restart docker.service"
 
       # download calicoctl.
-      host.vm.provision :shell, inline: "wget -qO /usr/local/bin/calicoctl #{calicoctl_url}", :privileged => true
+      host.vm.provision :shell, inline: "curl -L --silent #{calicoctl_url} -o /usr/local/bin/calicoctl"
 
       host.vm.provision :shell, inline: "chmod +x /usr/local/bin/calicoctl"
 

--- a/docs/calico-with-docker/without-docker-networking/vagrant-coreos/Vagrantfile
+++ b/docs/calico-with-docker/without-docker-networking/vagrant-coreos/Vagrantfile
@@ -19,14 +19,14 @@ num_instances=2
 instance_name_prefix="calico"
 
 # Official CoreOS channel from which updates should be downloaded
-update_channel='alpha'
+update_channel='stable'
 
 Vagrant.configure("2") do |config|
   # always use Vagrants insecure key
   config.ssh.insert_key = false
 
   config.vm.box = "coreos-%s" % update_channel
-  config.vm.box_version = ">= 962.0.0"
+  config.vm.box_version = ">= 1122.0.0"
   config.vm.box_url = "http://%s.release.core-os.net/amd64-usr/current/coreos_production_vagrant.json" % update_channel
 
   config.vm.provider :virtualbox do |v|

--- a/docs/calico-with-docker/without-docker-networking/vagrant-ubuntu/Vagrantfile
+++ b/docs/calico-with-docker/without-docker-networking/vagrant-ubuntu/Vagrantfile
@@ -50,7 +50,7 @@ Vagrant.configure(2) do |config|
       ]
 
       # download calicoctl.
-      host.vm.provision :shell, inline: "wget -qO /usr/local/bin/calicoctl #{calicoctl_url}", :privileged => true
+      host.vm.provision :shell, inline: "curl -L --silent #{calicoctl_url} -o /usr/local/bin/calicoctl"
       host.vm.provision :shell, inline: "chmod +x /usr/local/bin/calicoctl"
 
       # Calico uses etcd for clustering. Install it on the first host only.  We do not

--- a/docs/cni/kubernetes/vagrant-coreos/Vagrantfile
+++ b/docs/cni/kubernetes/vagrant-coreos/Vagrantfile
@@ -12,6 +12,7 @@ Vagrant.configure("2") do |config|
   config.ssh.insert_key = false
 
   config.vm.box = "coreos-%s" % update_channel
+  config.vm.box_version = ">= 1122.0.0"
   config.vm.box_url = "http://%s.release.core-os.net/amd64-usr/current/coreos_production_vagrant.json" % update_channel
 
   config.vm.provider :virtualbox do |v|

--- a/docs/cni/rkt/README.md
+++ b/docs/cni/rkt/README.md
@@ -168,7 +168,7 @@ either host, as long as they are created on the same network.
 
 e.g. On `calico-02` use wget to access the frontend service which is running on `calico-01`
 
-	sudo rkt run --net=frontend registry-1.docker.io/library/busybox --exec=/bin/wget -- -T 1 192.168.0.0/etc/passwd 2>/dev/null
+	sudo rkt run --net=frontend registry-1.docker.io/library/busybox --exec=/bin/wget -- -T 10 192.168.0.0/etc/passwd 2>/dev/null
 
 Expected output
 
@@ -183,7 +183,7 @@ You can repeat this command on calico-01 and check that access works the same fr
 ### 5.1 Checking network isolation
 Repeat the above command but try to access the backend from the frontend. Because we've not allowed access between these networks, the command will fail.
 
-	sudo rkt run --net=backend registry-1.docker.io/library/busybox --exec=/bin/wget -- -T 1 192.168.0.0/etc/passwd 2>/dev/null
+	sudo rkt run --net=backend registry-1.docker.io/library/busybox --exec=/bin/wget -- -T 2 192.168.0.0/etc/passwd 2>/dev/null
 
 Expected output
 
@@ -230,7 +230,7 @@ And we can now access our backend service from the frontend containers.
 
 On either host, run
 
-	sudo rkt run --net=frontend registry-1.docker.io/library/busybox --exec=/bin/wget -- -T 1 192.168.0.64/etc/passwd 2>/dev/null
+	sudo rkt run --net=frontend registry-1.docker.io/library/busybox --exec=/bin/wget -- -T 10 192.168.0.64/etc/passwd 2>/dev/null
 
 ### Open access to frontends
 We want to allow everyone to access our frontends, but only on port 80.
@@ -249,7 +249,7 @@ To produce the following output
 
 Now on either host, we can access the container directly
 
-	wget -T 1 192.168.0.0/etc/passwd
+	wget -T 10 192.168.0.0/etc/passwd
 
 ## 7. Resetting/Cleanup up
 If you want to start again from the beginning, then run the following commands on both hosts to ensure that all the rkt containers and systemd jobs are removed.

--- a/docs/cni/rkt/Vagrantfile
+++ b/docs/cni/rkt/Vagrantfile
@@ -5,14 +5,14 @@ num_instances=2
 instance_name_prefix="calico"
 
 # Official CoreOS channel from which updates should be downloaded
-update_channel='alpha'
+update_channel='stable'
 
 Vagrant.configure("2") do |config|
   # always use Vagrants insecure key
   config.ssh.insert_key = false
 
   config.vm.box = "coreos-%s" % update_channel
-  config.vm.box_version = ">= 949.0.0"
+  config.vm.box_version = ">= 1122.0.0"
   config.vm.box_url = "http://%s.release.core-os.net/amd64-usr/current/coreos_production_vagrant.json" % update_channel
 
   config.vm.provider :virtualbox do |v|


### PR DESCRIPTION
These were changes necessary to pass manual testing for the release.

Reference to coreos release.  Coreos alpha and stable are quite near in time, but the stable release works with Calico and will provide a better customer experience.
https://coreos.com/releases/