### PR TITLE
change default eth to match the latest Ubuntu vagrant setup

### DIFF
--- a/docs/calico-with-docker/docker-network-plugin/IPv6.md
+++ b/docs/calico-with-docker/docker-network-plugin/IPv6.md
@@ -33,11 +33,11 @@ have an IPv6 address assigned.
 
 On calico-01
 
-    sudo ip addr add fd80:24e2:f998:72d7::1/112 dev eth1
+    sudo ip addr add fd80:24e2:f998:72d7::1/112 dev enp0s8
 
 On calico-02
 
-    sudo ip addr add fd80:24e2:f998:72d7::2/112 dev eth1
+    sudo ip addr add fd80:24e2:f998:72d7::2/112 dev enp0s8
 
 Verify connectivity by pinging.
 


### PR DESCRIPTION
eth1 -> enp0s8

```bash

vagrant@calico-02:~$ ifconfig
docker0   Link encap:Ethernet  HWaddr 02:42:00:6c:4c:db
          inet addr:172.18.0.1  Bcast:0.0.0.0  Mask:255.255.0.0
          UP BROADCAST MULTICAST  MTU:1500  Metric:1
          RX packets:0 errors:0 dropped:0 overruns:0 frame:0
          TX packets:0 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:0
          RX bytes:0 (0.0 B)  TX bytes:0 (0.0 B)

enp0s3    Link encap:Ethernet  HWaddr 08:00:27:ee:32:98
          inet addr:10.0.2.15  Bcast:10.0.2.255  Mask:255.255.255.0
          inet6 addr: fe80::a00:27ff:feee:3298/64 Scope:Link
          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
          RX packets:69366 errors:0 dropped:0 overruns:0 frame:0
          TX packets:13934 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000
          RX bytes:95342352 (95.3 MB)  TX bytes:1022996 (1.0 MB)

**enp0s8**    Link encap:Ethernet  HWaddr 08:00:27:bb:50:e7
          inet addr:172.17.8.102  Bcast:172.17.8.255  Mask:255.255.255.0
          inet6 addr: fd80:24e2:f998:72d7::2/112 Scope:Global
          inet6 addr: fe80::a00:27ff:febb:50e7/64 Scope:Link
          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
          RX packets:77533 errors:0 dropped:0 overruns:0 frame:0
          TX packets:77590 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000
          RX bytes:5295881 (5.2 MB)  TX bytes:5202545 (5.2 MB)

```