### PR TITLE
Update manifests README to discuss self-hosted.

### DIFF
--- a/docs/cni/kubernetes/InstallAddons.md
+++ b/docs/cni/kubernetes/InstallAddons.md
@@ -13,7 +13,7 @@ Calico can be installed on Kubernetes using Kubernetes resources (DaemonSets, et
 The Calico self-hosted installation consists of three objects in the `kube-system` Namespace:
 - A `ConfigMap` which contains the Calico configuration.
 - A `DaemonSet` which installs the `calico/node` pod and CNI plugin.
-- A `ReplicationController` which installs the `calico/kube-policy-controller` pod.
+- A `ReplicaSet` which installs the `calico/kube-policy-controller` pod.
 
 To intall these components:
 ```

--- a/docs/cni/kubernetes/manifests/README.md
+++ b/docs/cni/kubernetes/manifests/README.md
@@ -1,0 +1,44 @@
+# Calico Kubernetes Hosted Install
+
+This directory contains Kubernetes manifests to deploy Calico on top of Kubernetes.
+
+- `calico-configmap.yaml`: Contains a Kubernetes ConfigMap for configuring the deployment.  Make sure the values
+in this file match your desired configuration.
+
+- `calico-hosted.yaml`: Contains a Kubernetes DaemonSet which install and runs Calico on each Kubernetes master and node.
+This also includes a ReplicaSet which deploys the Calico Kubernetes policy controller.
+
+Note that the Kubernetes hosted installation method is experimental and subject to change.
+
+# How it works
+
+The `calico-hosted.yaml` file contains all the necessary resources for installing Calico on each node in your Kubernetes cluster.
+
+It does the following things:
+- Installs the `calico/node` container on each host using a DaemonSet.
+- Installs the Calico CNI binaries and network config on each host using a DaemonSet.
+- Runs the `calico/kube-policy-controller` pod as a ReplicaSet.
+
+# Configuration options
+
+The `calico-configmap.yaml` provides a way to configure a Calico self-hosted installation.  It exposes
+the following configuration parameters:
+
+### etcd_endpoints
+
+The location of your etcd cluster.  The default in the provided manifest assumes that an etcd proxy is running on each node.
+
+### enable_bgp 
+
+Whether or not to run Calico BGP.  If false, then BGP will be disabled and Calico will enforce policy only.
+
+### cni_network_config
+
+The CNI network configuration to install on each node.  This field supports the following template fields, which will 
+be filled in automatically by the `calico/cni` container:
+
+- `__KUBERNETES_SERVICE_HOST__`: This will be replaced with the Kubernetes Service clusterIP. e.g 10.0.0.1 
+- `__KUBERNETES_SERVICE_PORT__`: This will be replaced with the Kubernetes Service port. e.g 443
+- `__SERVICEACCOUNT_TOKEN__`: This will be replaced with the serviceaccount token for the namespace.  Requires that Kubernetes be configured to create serviceaccount tokens.
+- `__ETCD_ENDPOINTS__`: This will be replaced with the etcd cluster specified in the ETCD_ENDPOINTS environment variable. e.g http://127.0.0.1:2379
+- `__KUBECONFIG_FILENAME__`: The name of the automatically generated kubeconfig file in the same directory as the CNI network config file.

--- a/docs/cni/kubernetes/manifests/README.md
+++ b/docs/cni/kubernetes/manifests/README.md
@@ -5,7 +5,7 @@ This directory contains Kubernetes manifests to deploy Calico on top of Kubernet
 - `calico-configmap.yaml`: Contains a Kubernetes ConfigMap for configuring the deployment.  Make sure the values
 in this file match your desired configuration.
 
-- `calico-hosted.yaml`: Contains a Kubernetes DaemonSet which install and runs Calico on each Kubernetes master and node.
+- `calico-hosted.yaml`: Contains a Kubernetes DaemonSet which installs and runs Calico on each Kubernetes master and node.
 This also includes a ReplicaSet which deploys the Calico Kubernetes policy controller.
 
 Note that the Kubernetes hosted installation method is experimental and subject to change.

--- a/docs/cni/kubernetes/manifests/calico-configmap.yaml
+++ b/docs/cni/kubernetes/manifests/calico-configmap.yaml
@@ -20,15 +20,17 @@ data:
     {
         "name": "k8s-pod-network",
         "type": "calico",
-        "etcd_endpoints": "http://127.0.0.1:2379",
+        "etcd_endpoints": "__ETCD_ENDPOINTS__",
         "log_level": "info",
         "ipam": {
             "type": "calico-ipam"
         },
         "policy": {
-            "type": "k8s"
+            "type": "k8s",
+             "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
+             "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
         },
         "kubernetes": {
-            "kubeconfig": "/etc/kubernetes/worker-kubeconfig.yaml"
+            "kubeconfig": "/etc/cni/net.d/__KUBECONFIG_FILENAME__"
         }
     }

--- a/docs/cni/kubernetes/manifests/calico-hosted.yaml
+++ b/docs/cni/kubernetes/manifests/calico-hosted.yaml
@@ -99,8 +99,8 @@ spec:
 
 # This manifest deploys the Calico policy controller on Kubernetes.
 # See https://github.com/projectcalico/k8s-policy
-apiVersion: v1
-kind: ReplicationController
+apiVersion: extensions/v1beta1
+kind: ReplicaSet 
 metadata:
   name: calico-policy-controller
   namespace: kube-system


### PR DESCRIPTION
This adds some documentation for the self-hosted work.

Relies on a new release of the CNI plugin which includes https://github.com/projectcalico/calico-cni/pull/177