### PR TITLE
Libnetwork plugin bundled in calico/node container

### DIFF
--- a/calico_node/Dockerfile
+++ b/calico_node/Dockerfile
@@ -30,6 +30,14 @@ RUN apk add --update-cache --repository "http://alpine.gliderlabs.com/alpine/edg
 # Install remaining runtime deps required for felix from the global repository
 RUN apk add --update-cache ip6tables ipset iputils iproute2 conntrack-tools
 
+# Install Python so libnetwork-plugin can run
+RUN apk --no-cache add python py-setuptools
+
+# Actually install libnetwork-plugin. A python dev environment (and git) is installed so libnetwork-plugin can be pip installed.
+# Finally the dev environment is removed. Doing this in one image layer minimized the final image size.
+RUN apk --no-cache add --virtual temp py-pip git gcc python-dev musl-dev && pip install git+https://github.com/projectcalico/libnetwork-plugin.git && \
+    pip install git+https://github.com/projectcalico/libcalico.git && apk del --purge temp
+
 # Copy in the filesystem - this contains felix, bird, gobgp etc...
 COPY filesystem /
 

--- a/calico_node/filesystem/etc/rc.local
+++ b/calico_node/filesystem/etc/rc.local
@@ -67,4 +67,11 @@ case "$CALICO_NETWORKING_BACKEND" in
 	;;
 esac
 
+# If running libnetwork plugin in a separate container, CALICO_LIBNETWORK_ENABLED would be false. 
+# CALICO_LIBNETWORK_ENABLED is "false" by default. It can be set by passing `--libnetwork` flag while starting the calico/node via calicoctl
+if [ "$CALICO_LIBNETWORK_ENABLED" == "true" ]; then
+	echo "CALICO_LIBNETWORK_ENABLED is true - start libnetwork service"
+	mv /etc/service/available/libnetwork  /etc/service/enabled/
+fi
+
 echo "Calico node started successfully"

--- a/calico_node/filesystem/etc/service/available/libnetwork/log/run
+++ b/calico_node/filesystem/etc/service/available/libnetwork/log/run
@@ -1,0 +1,5 @@
+#!/bin/sh
+LOGDIR=/var/log/calico/libnetwork
+mkdir -p $LOGDIR
+# Prefix each line with a timestamp
+exec svlogd -tt $LOGDIR

--- a/calico_node/filesystem/etc/service/available/libnetwork/run
+++ b/calico_node/filesystem/etc/service/available/libnetwork/run
@@ -1,0 +1,15 @@
+#!/bin/sh
+exec 2>&1
+GUNICORN=/usr/bin/gunicorn
+PID=/var/run/gunicorn.pid
+APP=libnetwork.driver_plugin:app
+
+if [ -f $PID ]; then rm $PID; fi
+
+exec $GUNICORN --pid=$PID \
+-b unix:///run/docker/plugins/calico.sock $APP \
+--timeout 5 \
+--log-level=info \
+--workers 1 \
+--worker-class gevent \
+--access-logfile -


### PR DESCRIPTION
- The new behavior is if calico/node is started with `calicoctl` and `--libnetwork` flag is passed then instead of running libnetwork-plugin in a separate container, we run it inside calico/node container.

- if calico/node is not started with `calicoctl` (like in case of k8s or manually starting the container), libnetwork can be enabled by passing an env var `CALICO_LIBNETWORK_ENABLED`, which is `false` by default and doesn't run libnetwork unless it's set to `true`