### PR TITLE
Deps required for new urllib3 version + IP SAN support

### DIFF
--- a/calico_node/Dockerfile
+++ b/calico_node/Dockerfile
@@ -28,15 +28,17 @@ RUN apk --no-cache add wget ca-certificates libgcc && \
 RUN apk add --update-cache --repository "http://alpine.gliderlabs.com/alpine/edge/community" runit
 
 # Install remaining runtime deps required for felix from the global repository
-RUN apk add --update-cache ip6tables ipset iputils iproute2 conntrack-tools
+RUN apk add --update-cache ip6tables ipset iputils iproute2 conntrack-tools openssl-dev libffi-dev
 
 # Install Python so libnetwork-plugin can run
 RUN apk --no-cache add python py-setuptools
 
 # Actually install libnetwork-plugin. A python dev environment (and git) is installed so libnetwork-plugin can be pip installed.
 # Finally the dev environment is removed. Doing this in one image layer minimized the final image size.
-RUN apk --no-cache add --virtual temp py-pip git gcc python-dev musl-dev && pip install git+https://github.com/projectcalico/libnetwork-plugin.git && \
-    pip install git+https://github.com/projectcalico/libcalico.git && apk del --purge temp
+RUN apk --no-cache add --virtual temp py-pip git gcc python-dev musl-dev && \
+    pip install git+https://github.com/projectcalico/libnetwork-plugin.git && \
+    pip install git+https://github.com/projectcalico/libcalico.git && \
+    apk del --purge temp
 
 # Copy in the filesystem - this contains felix, bird, gobgp etc...
 COPY filesystem /


### PR DESCRIPTION
Depends on:
- New libcalico release with https://github.com/projectcalico/libcalico/pull/153/files
- New felix release with https://github.com/projectcalico/felix/pull/1125

Currently, both are using my own forks.