### PR TITLE
Allow to customize pip repos during node image build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,8 @@ BUILD_CONTAINER_NAME?=calico/build:latest
 NODE_CONTAINER_DIR=calico_node
 NODE_CONTAINER_NAME?=calico/node:latest
 NODE_CONTAINER_FILES=$(shell find $(NODE_CONTAINER_DIR)/filesystem/{etc,sbin} -type f)
+# we can pass --build-arg during node image building
+NODE_CONTAINER_BUILD_ARGS?=
 NODE_CONTAINER_CREATED=$(NODE_CONTAINER_DIR)/.calico_node.created
 NODE_CONTAINER_BIN_DIR=$(NODE_CONTAINER_DIR)/filesystem/bin
 NODE_CONTAINER_BINARIES=startup allocate-ipip-addr calico-felix bird calico-bgp-daemon confd
@@ -51,7 +53,7 @@ calico-node-latest.aci: calico-node.tar
 
 # Build calico/node docker image
 $(NODE_CONTAINER_CREATED): $(NODE_CONTAINER_DIR)/Dockerfile  $(addprefix $(NODE_CONTAINER_BIN_DIR)/,$(NODE_CONTAINER_BINARIES))
-	docker build -t $(NODE_CONTAINER_NAME) $(NODE_CONTAINER_DIR)
+	docker build $(NODE_CONTAINER_BUILD_ARGS) -t $(NODE_CONTAINER_NAME) $(NODE_CONTAINER_DIR)
 	touch $@
 
 # Build binary from python files, e.g. startup.py or allocate-ipip-addr.py

--- a/calico_node/Dockerfile
+++ b/calico_node/Dockerfile
@@ -14,6 +14,11 @@
 FROM gliderlabs/alpine:3.4
 MAINTAINER Tom Denham <tom@projectcalico.org>
 
+ARG LIBCALICO_REPO="https://github.com/projectcalico/libcalico.git"
+ARG LIBCALICO_VER="master"
+ARG LIBNETWORK_REPO="https://github.com/projectcalico/libnetwork-plugin.git"
+ARG LIBNETWORK_VER="master"
+
 # Download and install glibc for use by non-static binaries that require it.
 RUN apk --no-cache add wget ca-certificates libgcc && \
     wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub && \
@@ -33,10 +38,17 @@ RUN apk add --no-cache ip6tables ipset iputils iproute2 conntrack-tools
 # Install Python so libnetwork-plugin can run
 RUN apk --no-cache add python py-setuptools
 
-# Actually install libnetwork-plugin. A python dev environment (and git) is installed so libnetwork-plugin can be pip installed.
+# Copy "shared directory" which can be used to pass custom files (local git repos,
+# that can be used by pip install git+file:///)
+COPY node_share /tmp/node_share
+
+# Actually install libnetwork-plugin. A python dev environment (and git) is installed so
+# libnetwork-plugin can be pip installed.
 # Finally the dev environment is removed. Doing this in one image layer minimized the final image size.
-RUN apk --no-cache add --virtual temp py-pip git gcc python-dev musl-dev libffi-dev openssl-dev && pip install git+https://github.com/projectcalico/libnetwork-plugin.git && \
-    pip install git+https://github.com/projectcalico/libcalico.git && apk del --purge temp
+RUN apk --no-cache add --virtual temp py-pip git gcc python-dev musl-dev libffi-dev openssl-dev && \
+  pip install git+$LIBNETWORK_REPO@$LIBNETWORK_VER && \
+  pip install git+$LIBCALICO_REPO@$LIBCALICO_VER && \
+  apk del --purge temp
 
 # Copy in the filesystem - this contains felix, bird, gobgp etc...
 COPY filesystem /

--- a/calico_node/Dockerfile
+++ b/calico_node/Dockerfile
@@ -48,7 +48,8 @@ COPY node_share /tmp/node_share
 RUN apk --no-cache add --virtual temp py-pip git gcc python-dev musl-dev libffi-dev openssl-dev && \
   pip install git+$LIBNETWORK_REPO@$LIBNETWORK_VER && \
   pip install git+$LIBCALICO_REPO@$LIBCALICO_VER && \
-  apk del --purge temp
+  apk del --purge temp && \
+  rm -rf /tmp/node_share
 
 # Copy in the filesystem - this contains felix, bird, gobgp etc...
 COPY filesystem /


### PR DESCRIPTION
Make building calico/node more friendly to CI.
Since calico/node image build process hardly depends on two pip
repositories (from git):
  * libcalico
  * libnetwork-plugin
we need to have an ability to test pull-requests/patches to the
above repos against calico-containers before merge. This patch
doesn't break the default behaviour (installing from github repos),
but allows us to customize pip repositories path.

Changes:
 * Add ARG parameters to calico/node Dockerfile with the defaults:
   ARG LIBCALICO_REPO="https://github.com/projectcalico/libcalico.git"
   ARG LIBCALICO_VER="master"
   ARG LIBNETWORK_REPO="https://github.com/projectcalico/libnetwork-plugin.git"
   ARG LIBNETWORK_VER="master"
 * COPY share dir `node_share` inside container to `/tmp/node_share`
   Since docker build doesn't support mounting we have to use copy
   This share folder can be used to "deliver" custom pip repos
   inside container
 * run pip install from path defined by variables
 * Dockerfile for node. We add NODE_CONTAINER_BUILD_ARGS which
   can be used to bypass ARGs variables in format (see docker build
   with --build-arg):
     --build-arg LIBCALICO_VER=v0.22.0 --build-arg ...

How to use:
  1. Simple case. Build calico/node using libcalico pip repo from
     tag v0.15.0:

        make node_image \
          NODE_CONTAINER_BUILD_ARGS="--build-arg LIBCALICO_VER=v0.22.0"

  2. Advanced case. Build calico/node with not yet merged pull
     request:
     a. Prepare custom pip repo in calico_node/node_share/libcalico
        by checking out libcalico code with merging pull request
     b. Run build with new repo path:

        make node_image \
          NODE_CONTAINER_BUILD_ARGS="--build-arg LIBCALICO_VER=mytag \
             --build-arg LIBCALICO_REPO=file:///tmp/node_share/libcalico"