### PR TITLE
error reporting + minor bugfixes

### DIFF
--- a/calicoctl/calicoctl.go
+++ b/calicoctl/calicoctl.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"fmt"
-	"strings"
 
 	"os"
 
@@ -49,7 +48,6 @@ Description:
   to view and manage endpoint configuration, and to manage a Calico node instance.
 
   See 'calicoctl <command> --help' to read about a specific subcommand.`
-	var err error
 	arguments, _ := docopt.Parse(doc, nil, true, commands.VERSION_SUMMARY, true, false)
 
 	if logLevel := arguments["--log-level"]; logLevel != nil {
@@ -70,28 +68,23 @@ Description:
 
 		switch command {
 		case "create":
-			err = commands.Create(args)
+			commands.Create(args)
 		case "replace":
-			err = commands.Replace(args)
+			commands.Replace(args)
 		case "apply":
-			err = commands.Apply(args)
+			commands.Apply(args)
 		case "delete":
-			err = commands.Delete(args)
+			commands.Delete(args)
 		case "get":
-			err = commands.Get(args)
+			commands.Get(args)
 		case "version":
-			err = commands.Version(args)
+			commands.Version(args)
 		case "node":
-			err = commands.Node(args)
+			commands.Node(args)
 		case "ipam":
-			err = commands.IPAM(args)
+			commands.IPAM(args)
 		default:
 			fmt.Println(doc)
-		}
-
-		if err != nil {
-			fmt.Printf("Error executing command. Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.\n", strings.Join(args, " "))
-			os.Exit(1)
 		}
 	}
 }

--- a/calicoctl/commands/apply.go
+++ b/calicoctl/commands/apply.go
@@ -16,6 +16,8 @@ package commands
 
 import (
 	"fmt"
+	"os"
+	"strings"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docopt/docopt-go"
@@ -23,7 +25,7 @@ import (
 	"github.com/projectcalico/calico-containers/calicoctl/commands/constants"
 )
 
-func Apply(args []string) error {
+func Apply(args []string) {
 	doc := constants.DatastoreIntro + `Usage:
   calicoctl apply --filename=<FILENAME> [--config=<CONFIG>]
 
@@ -64,10 +66,11 @@ Description:
   it is not sufficient to supply only the fields that are being updated.`
 	parsedArgs, err := docopt.Parse(doc, args, true, "", false, false)
 	if err != nil {
-		return err
+		fmt.Printf("Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.\n", strings.Join(args, " "))
+		os.Exit(1)
 	}
 	if len(parsedArgs) == 0 {
-		return nil
+		return
 	}
 
 	results := executeConfigCommand(parsedArgs, actionApply)
@@ -75,6 +78,7 @@ Description:
 
 	if results.fileInvalid {
 		fmt.Printf("Error processing input file: %v\n", results.err)
+		os.Exit(1)
 	} else if results.numHandled == 0 {
 		if results.numResources == 0 {
 			fmt.Printf("No resources specified in file\n")
@@ -85,6 +89,7 @@ Description:
 		} else {
 			fmt.Printf("Failed to apply any resources: %v\n", results.err)
 		}
+		os.Exit(1)
 	} else if results.err == nil {
 		if results.singleKind != "" {
 			fmt.Printf("Successfully applied %d '%s' resource(s)\n", results.numHandled, results.singleKind)
@@ -101,7 +106,6 @@ Description:
 				results.numHandled, results.numResources)
 		}
 		fmt.Printf("Hit error: %v\n", results.err)
+		os.Exit(1)
 	}
-
-	return results.err
 }

--- a/calicoctl/commands/create.go
+++ b/calicoctl/commands/create.go
@@ -16,6 +16,8 @@ package commands
 
 import (
 	"fmt"
+	"os"
+	"strings"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docopt/docopt-go"
@@ -23,7 +25,7 @@ import (
 	"github.com/projectcalico/calico-containers/calicoctl/commands/constants"
 )
 
-func Create(args []string) error {
+func Create(args []string) {
 	doc := constants.DatastoreIntro + `Usage:
   calicoctl create --filename=<FILENAME> [--skip-exists] [--config=<CONFIG>]
 
@@ -61,10 +63,11 @@ Description:
   number of resources successfully created.`
 	parsedArgs, err := docopt.Parse(doc, args, true, "", false, false)
 	if err != nil {
-		return err
+		fmt.Printf("Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.\n", strings.Join(args, " "))
+		os.Exit(1)
 	}
 	if len(parsedArgs) == 0 {
-		return nil
+		return
 	}
 
 	results := executeConfigCommand(parsedArgs, actionCreate)
@@ -72,6 +75,7 @@ Description:
 
 	if results.fileInvalid {
 		fmt.Printf("Error processing input file: %v\n", results.err)
+		os.Exit(1)
 	} else if results.numHandled == 0 {
 		if results.numResources == 0 {
 			fmt.Printf("No resources specified in file\n")
@@ -82,6 +86,7 @@ Description:
 		} else {
 			fmt.Printf("Failed to create any resources: %v\n", results.err)
 		}
+		os.Exit(1)
 	} else if results.err == nil {
 		if results.singleKind != "" {
 			fmt.Printf("Successfully created %d '%s' resource(s)\n", results.numHandled, results.singleKind)
@@ -98,7 +103,6 @@ Description:
 				results.numHandled, results.numResources)
 		}
 		fmt.Printf("Hit error: %v\n", results.err)
+		os.Exit(1)
 	}
-
-	return results.err
 }

--- a/calicoctl/commands/delete.go
+++ b/calicoctl/commands/delete.go
@@ -16,6 +16,8 @@ package commands
 
 import (
 	"fmt"
+	"os"
+	"strings"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docopt/docopt-go"
@@ -23,7 +25,7 @@ import (
 	"github.com/projectcalico/calico-containers/calicoctl/commands/constants"
 )
 
-func Delete(args []string) error {
+func Delete(args []string) {
 	doc := constants.DatastoreIntro + `Usage:
   calicoctl delete ([--node=<NODE>] [--orchestrator=<ORCH>] [--workload=<WORKLOAD>] [--scope=<SCOPE>]
                     (<KIND> [<NAME>]) |
@@ -77,10 +79,11 @@ Description:
   number of resources successfully deleted.`
 	parsedArgs, err := docopt.Parse(doc, args, true, "", false, false)
 	if err != nil {
-		return err
+		fmt.Printf("Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.\n", strings.Join(args, " "))
+		os.Exit(1)
 	}
 	if len(parsedArgs) == 0 {
-		return nil
+		return
 	}
 
 	results := executeConfigCommand(parsedArgs, actionDelete)
@@ -88,6 +91,7 @@ Description:
 
 	if results.fileInvalid {
 		fmt.Printf("Error processing input file: %v\n", results.err)
+		os.Exit(1)
 	} else if results.numHandled == 0 {
 		if results.numResources == 0 {
 			fmt.Printf("No resources specified in file\n")
@@ -98,6 +102,7 @@ Description:
 		} else {
 			fmt.Printf("Failed to delete any resources: %v\n", results.err)
 		}
+		os.Exit(1)
 	} else if results.err == nil {
 		if results.singleKind != "" {
 			fmt.Printf("Successfully deleted %d '%s' resource(s)\n", results.numHandled, results.singleKind)
@@ -114,7 +119,6 @@ Description:
 				results.numHandled, results.numResources)
 		}
 		fmt.Printf("Hit error: %v\n", results.err)
+		os.Exit(1)
 	}
-
-	return results.err
 }

--- a/calicoctl/commands/ipam.go
+++ b/calicoctl/commands/ipam.go
@@ -25,7 +25,7 @@ import (
 )
 
 // IPAM takes keyword with an IP address then calls the subcommands.
-func IPAM(args []string) error {
+func IPAM(args []string) {
 	doc := constants.DatastoreIntro + `Usage:
   calicoctl ipam <command> [<args>...]
 
@@ -41,10 +41,11 @@ Description:
   See 'calicoctl ipam <command> --help' to read about a specific subcommand.`
 	arguments, err := docopt.Parse(doc, args, true, "", true, false)
 	if err != nil {
-		return err
+		fmt.Printf("Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.\n", strings.Join(args, " "))
+		os.Exit(1)
 	}
 	if arguments["<command>"] == nil {
-		return nil
+		return
 	}
 
 	command := arguments["<command>"].(string)
@@ -52,17 +53,10 @@ Description:
 
 	switch command {
 	case "release":
-		err = ipam.Release(args)
+		ipam.Release(args)
 	case "show":
-		err = ipam.Show(args)
+		ipam.Show(args)
 	default:
 		fmt.Println(doc)
 	}
-
-	if err != nil {
-		fmt.Printf("Error executing command. Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.\n", strings.Join(args, " "))
-		os.Exit(1)
-	}
-
-	return nil
 }

--- a/calicoctl/commands/ipam/show.go
+++ b/calicoctl/commands/ipam/show.go
@@ -16,6 +16,8 @@ package ipam
 
 import (
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/projectcalico/calico-containers/calicoctl/commands/constants"
 	"github.com/projectcalico/libcalico-go/lib/net"
@@ -25,13 +27,13 @@ import (
 )
 
 // IPAM takes keyword with an IP address then calls the subcommands.
-func Show(args []string) error {
+func Show(args []string) {
 	doc := constants.DatastoreIntro + `Usage:
   calicoctl ipam show --ip=<IP> [--config=<CONFIG>]
 
 Options:
-  -h --help      Show this screen.
-     --ip=<IP>   IP address
+  -h --help                 Show this screen.
+     --ip=<IP>              IP address
   -c --config=<CONFIG>      Filename containing connection configuration in YAML or JSON format.
                             [default: /etc/calico/calicoctl.cfg]
 
@@ -42,10 +44,11 @@ Description:
 
 	parsedArgs, err := docopt.Parse(doc, args, true, "", false, false)
 	if err != nil {
-		return err
+		fmt.Printf("Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.\n", strings.Join(args, " "))
+		os.Exit(1)
 	}
 	if len(parsedArgs) == 0 {
-		return nil
+		return
 	}
 
 	// Create a new backend client from env vars.
@@ -65,7 +68,7 @@ Description:
 	// so not returning it to the caller.
 	if err != nil {
 		fmt.Println(err)
-		return nil
+		return
 	}
 
 	// IP address is assigned with attributes.
@@ -75,6 +78,4 @@ Description:
 		// IP address is assigned but attributes are not set.
 		fmt.Printf("No attributes defined for IP %s\n", ip)
 	}
-
-	return nil
 }

--- a/calicoctl/commands/node.go
+++ b/calicoctl/commands/node.go
@@ -25,7 +25,7 @@ import (
 )
 
 // Node function is a switch to node related sub-commands
-func Node(args []string) error {
+func Node(args []string) {
 	var err error
 	doc := constants.DatastoreIntro + `Usage:
   calicoctl node <command> [<args>...]
@@ -44,10 +44,11 @@ Description:
   See 'calicoctl node <command> --help' to read about a specific subcommand.`
 	arguments, err := docopt.Parse(doc, args, true, "", true, false)
 	if err != nil {
-		return err
+		fmt.Printf("Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.\n", strings.Join(args, " "))
+		os.Exit(1)
 	}
 	if arguments["<command>"] == nil {
-		return nil
+		return
 	}
 
 	command := arguments["<command>"].(string)
@@ -55,19 +56,12 @@ Description:
 
 	switch command {
 	case "status":
-		err = node.Status(args)
+		node.Status(args)
 	case "diags":
-		err = node.Diags(args)
+		node.Diags(args)
 	case "checksystem":
-		err = node.Checksystem(args)
+		node.Checksystem(args)
 	default:
 		fmt.Println(doc)
 	}
-
-	if err != nil {
-		fmt.Printf("Error executing command. Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.\n", strings.Join(args, " "))
-		os.Exit(1)
-	}
-
-	return nil
 }

--- a/calicoctl/commands/replace.go
+++ b/calicoctl/commands/replace.go
@@ -15,6 +15,9 @@
 package commands
 
 import (
+	"os"
+	"strings"
+
 	"github.com/docopt/docopt-go"
 
 	"fmt"
@@ -23,7 +26,7 @@ import (
 	"github.com/projectcalico/calico-containers/calicoctl/commands/constants"
 )
 
-func Replace(args []string) error {
+func Replace(args []string) {
 	doc := constants.DatastoreIntro + `Usage:
   calicoctl replace --filename=<FILENAME> [--config=<CONFIG>]
 
@@ -60,10 +63,11 @@ Description:
   to supply only the fields that are being updated.`
 	parsedArgs, err := docopt.Parse(doc, args, true, "", false, false)
 	if err != nil {
-		return err
+		fmt.Printf("Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.\n", strings.Join(args, " "))
+		os.Exit(1)
 	}
 	if len(parsedArgs) == 0 {
-		return nil
+		return
 	}
 
 	results := executeConfigCommand(parsedArgs, actionUpdate)
@@ -71,6 +75,7 @@ Description:
 
 	if results.fileInvalid {
 		fmt.Printf("Error processing input file: %v\n", results.err)
+		os.Exit(1)
 	} else if results.numHandled == 0 {
 		if results.numResources == 0 {
 			fmt.Printf("No resources specified in file\n")
@@ -81,6 +86,7 @@ Description:
 		} else {
 			fmt.Printf("Failed to replace any resources: %v\n", results.err)
 		}
+		os.Exit(1)
 	} else if results.err == nil {
 		if results.singleKind != "" {
 			fmt.Printf("Successfully replaced %d '%s' resource(s)\n", results.numHandled, results.singleKind)
@@ -97,7 +103,6 @@ Description:
 				results.numHandled, results.numResources)
 		}
 		fmt.Printf("Hit error: %v\n", results.err)
+		os.Exit(1)
 	}
-
-	return results.err
 }

--- a/calicoctl/commands/version.go
+++ b/calicoctl/commands/version.go
@@ -16,6 +16,8 @@ package commands
 
 import (
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/docopt/docopt-go"
 )
@@ -27,7 +29,7 @@ func init() {
 	VERSION_SUMMARY = "calicoctl version " + VERSION + ", build " + GIT_REVISION
 }
 
-func Version(args []string) error {
+func Version(args []string) {
 	doc := `Usage:
   calicoctl version
 
@@ -38,14 +40,14 @@ Description:
   Display the version of calicoctl.`
 	arguments, err := docopt.Parse(doc, args, true, "", false, false)
 	if err != nil {
-		return err
+		fmt.Printf("Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.\n", strings.Join(args, " "))
+		os.Exit(1)
 	}
 	if len(arguments) == 0 {
-		return nil
+		return
 	}
 
 	fmt.Println("Version:     ", VERSION)
 	fmt.Println("Build date:  ", BUILD_DATE)
 	fmt.Println("Git commit:  ", GIT_REVISION)
-	return nil
 }


### PR DESCRIPTION
- handle errors locally instead of bubbling them up
- Print useful message when an invalid command is passed
- return proper exit codes (0 - success, 1 - failure/partial success)
- fix a bug where Felix SIG command wasn't getting executed
- some code tidy-up

fixes [#155](https://github.com/projectcalico/libcalico-go/issues/155)
