### PR TITLE
Fix release scripts

### DIFF
--- a/release-scripts/do_release.py
+++ b/release-scripts/do_release.py
@@ -62,8 +62,8 @@ CANDIDATE_VERSION_REPLACE = [
     (re.compile(r'http://www\.projectcalico\.org/builds/calicoctl'),
      'http://www.projectcalico.org/builds/calicoctl?circleci-branch={version}-candidate'),
 
-    (re.compile(r'git\+https://github\.com/projectcalico/calico\.git'),
-     'git+https://github.com/projectcalico/calico.git@{calico-version}'),
+    (re.compile(r'git\+https://github\.com/projectcalico/felix\.git'),
+     'git+https://github.com/projectcalico/felix.git@{calico-version}'),
 
     (re.compile(r'git\+https://github\.com/projectcalico/libcalico\.git@master'),
      'git+https://github.com/projectcalico/libcalico.git@{libcalico-version}'),
@@ -167,7 +167,7 @@ def start_release():
 
         calico_version = \
             utils.get_github_library_version("calico (felix)", __felix_version__,
-                                             "https://github.com/projectcalico/calico")
+                                             "https://github.com/projectcalico/felix")
         libcalico_version = \
             utils.get_github_library_version("libcalico", __libcalico_version__,
                                              "https://github.com/projectcalico/libcalico")

--- a/release-scripts/utils.py
+++ b/release-scripts/utils.py
@@ -30,7 +30,6 @@ from calico_ctl import __version__
 # Path names relative to the root of the project
 PATH_CALICOCTL_NODE = path.join("calicoctl", "calico_ctl", "node.py")
 PATH_CALICOCTL_INIT = path.join("calicoctl", "calico_ctl", "__init__.py")
-PATH_CALICONODE_BUILD = path.join("calico_node", "build.sh")
 PATH_MAKEFILE = "Makefile"
 PATH_MAIN_README = "README.md"
 PATH_DOCS = "docs"
@@ -52,7 +51,6 @@ README_RE = re.compile(r'https://github\.com/projectcalico/calico\-containers/bl
 # paths are relative to the project root.
 UPDATE_FILES_STATIC = [PATH_MAIN_README,
                        PATH_CALICOCTL_NODE,
-                       PATH_CALICONODE_BUILD,
                        PATH_CALICOCTL_INIT,
                        PATH_MAKEFILE]
 UPDATE_FILES_DIRS = [PATH_DOCS]


### PR DESCRIPTION
Update release scripts to account for the fact that:
- `calico/node` doesn't use `build.sh` anymore
- `projectcalico/calico` was renamed to `projectcalico/felix`
