### PR TITLE
Add config commands and node as a resource

### DIFF
--- a/calicoctl/calicoctl.go
+++ b/calicoctl/calicoctl.go
@@ -83,6 +83,8 @@ Description:
 			commands.Node(args)
 		case "ipam":
 			commands.IPAM(args)
+		case "config":
+			commands.Config(args)
 		default:
 			fmt.Println(doc)
 		}

--- a/calicoctl/commands/apply.go
+++ b/calicoctl/commands/apply.go
@@ -38,32 +38,36 @@ Examples:
 
 Options:
   -h --help                 Show this screen.
-  -f --filename=<FILENAME>  Filename to use to apply the resource.  If set to "-" loads from stdin.
-  -c --config=<CONFIG>      Filename containing connection configuration in YAML or JSON format.
+  -f --filename=<FILENAME>  Filename to use to apply the resource.  If set to
+                            "-" loads from stdin.
+  -c --config=<CONFIG>      Filename containing connection configuration in
+                            YAML or JSON format.
                             [default: /etc/calico/calicoctl.cfg]
 
 Description:
-  The apply command is used to create or replace a set of resources by filename or stdin.  JSON and
-  YAML formats are accepted.
+  The apply command is used to create or replace a set of resources by filename
+  or stdin.  JSON and YAML formats are accepted.
 
-  Valid resource types are node, bgpPeer, hostEndpoint, workloadEndpoint, policy, pool and
-  profile.
+  Valid resource types are node, bgpPeer, hostEndpoint, workloadEndpoint, pool,
+  policy, and profile.
 
   When applying a resource:
-  -  if the resource does not already exist (as determined by it's primary identifiers)
-     then it is created
-  -  if the resource already exists then the specification for that resource is replaced
-     in it's entirety by the new resource specification.
+  -  if the resource does not already exist (as determined by it's primary
+     identifiers) then it is created
+  -  if the resource already exists then the specification for that resource is
+     replaced in it's entirety by the new resource specification.
 
-  The output of the command indicates how many resources were successfully applied, and the error
-  reason if an error occurred.
+  The output of the command indicates how many resources were successfully
+  applied, and the error reason if an error occurred.
 
-  The resources are applied in the order they are specified.  In the event of a failure
-  applying a specific resource it is possible to work out which resource failed based on the
-  number of resources successfully applied
+  The resources are applied in the order they are specified.  In the event of a
+  failure applying a specific resource it is possible to work out which
+  resource failed based on the number of resources successfully applied
 
-  When applying a resource to perform an update, the complete resource spec must be provided,
-  it is not sufficient to supply only the fields that are being updated.`
+  When applying a resource to perform an update, the complete resource spec
+  must be provided, it is not sufficient to supply only the fields that are
+  being updated.
+`
 	parsedArgs, err := docopt.Parse(doc, args, true, "", false, false)
 	if err != nil {
 		fmt.Printf("Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.\n", strings.Join(args, " "))

--- a/calicoctl/commands/config.go
+++ b/calicoctl/commands/config.go
@@ -1,0 +1,319 @@
+// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"errors"
+	"os"
+	"strings"
+
+	"github.com/docopt/docopt-go"
+	"github.com/projectcalico/libcalico-go/lib/client"
+	"github.com/projectcalico/calico-containers/calicoctl/commands/constants"
+	"github.com/projectcalico/calico-containers/calicoctl/commands/clientmgr"
+	"fmt"
+	"strconv"
+)
+
+func Config(args []string) {
+	doc := constants.DatastoreIntro + `Usage:
+  calicoctl config set <NAME> <VALUE> [--node=<NODE>] [--config=<CONFIG>]
+  calicoctl config unset <NAME> [--node=<NODE>] [--config=<CONFIG>]
+  calicoctl config view <NAME> [--node=<NODE>] [--config=<CONFIG>]
+
+Examples:
+  # Turn off the full BGP node-to-node mesh
+  calicoctl config set nodeToNodeMesh off
+
+  # Set global log level to warning
+  calicoctl config set logLevel warning
+
+  # Set log level to info for node "node1"
+  calicoctl config set logLevel info --node=node1
+
+  # Display the full set of config values
+  calicoctl config view
+
+Options:
+  -n --node=<NODE>      The node name.
+  -c --config=<CONFIG>  Filename containing connection configuration in YAML or
+                        JSON format.
+                        [default: /etc/calico/calicoctl.cfg]
+
+Description:
+
+These commands can be used to manage global system-wide configuration and some
+node-specific low level configuration.
+
+The --node option is used to specify the node name for low-level configuration
+that is specific to a particular node.
+
+For configuration that has both global values and node-specific values, the
+--node parameter is optional:  including the parameter will manage the
+node-specific value,  not including it will manage the global value.  For these
+options, if the node-specific value is unset, the global value will be used on
+the node.
+
+For configuration that is only global, the --node option should not be
+included.  Unsetting the global value will return it to it's original default.
+
+For configuration that is node-specific only, the --node option should be
+included.  Unsetting the node value will remove the configuration, and for
+supported configuration will then inherit the value from the global settings.
+
+The table below details the valid config options.
+
+ Name            | Scope       | Value                                  |
+-----------------+-----------+-------------+----------------------------+
+ logLevel        | global,node | none,debug,info,warning,error,critical |
+ nodeToNodeMesh  | global      | on,off                                 |
+ asNumber        | global      | 0-4294967295                           |
+ ipip            | global      | on,off                                 |
+`
+	parsedArgs, err := docopt.Parse(doc, args, true, "calicoctl", false, false)
+	if err != nil {
+		fmt.Printf("Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.\n", strings.Join(args, " "))
+		os.Exit(1)
+	}
+	if len(parsedArgs) == 0 {
+		return
+	}
+
+	// Load the client config and connect.
+	cf := parsedArgs["--config"].(string)
+	client, err := clientmgr.NewClient(cf)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	// From the command line arguments construct the Config object to send to the client.
+	node := argStringOrBlank(parsedArgs, "--node")
+	name := argStringOrBlank(parsedArgs, "<NAME>")
+	value := argStringOrBlank(parsedArgs, "<VALUE>")
+
+	// For now we map each option through to separate config methods, but
+	// eventually we'll aim to have a config style resource and this will
+	// become more generic.
+	var ct configType
+	switch strings.ToLower(name) {
+	case "loglevel":
+		ct = loglevel{client.Config()}
+	case "nodetonodemesh":
+		ct = nodemesh{client.Config()}
+	case "asnumber":
+		ct = asnum{client.Config()}
+	case "ipip":
+		ct = ipip{client.Config()}
+	default:
+		fmt.Printf("Error executing command: unrecognised config name '%s'\n", name)
+		os.Exit(1)
+	}
+
+	if parsedArgs["set"].(bool) {
+		err = ct.set(value, node)
+	} else if parsedArgs["unset"].(bool) {
+		err = ct.unset(node)
+	} else {
+		err = ct.view(node)
+	}
+
+	if err != nil {
+		fmt.Printf("Error executing command: %s\n", err)
+		os.Exit(1)
+	}
+
+	return
+}
+
+// Config management interface.
+type configType interface {
+	set(value, node string) error
+	unset(node string) error
+	view(node string) error
+}
+
+// loglevel implements the configType interface.
+type loglevel struct {
+	c client.ConfigInterface
+}
+
+func (l loglevel) set(value, node string) error {
+	if node == "" {
+		return l.c.SetGlobalLogLevel(value)
+	} else {
+		return l.c.SetNodeLogLevel(node, value)
+	}
+}
+
+func (l loglevel) unset(node string) error {
+	if node == "" {
+		return l.c.SetGlobalLogLevel(client.GlobalDefaultLogLevel)
+	} else {
+		return l.c.SetNodeLogLevelUseGlobal(node)
+	}
+}
+
+func (l loglevel) view(node string) error {
+	var level string
+	var location client.ConfigLocation
+	var err error
+	if node == "" {
+		level, err = l.c.GetGlobalLogLevel()
+		location = client.ConfigLocationNone
+	} else {
+		level, location, err = l.c.GetNodeLogLevel(node)
+	}
+	if err != nil {
+		return err
+	}
+	if location == client.ConfigLocationGlobal {
+		fmt.Printf("%s (inherited from global)\n", level)
+	} else {
+		fmt.Printf("%s\n", level)
+	}
+	return nil
+}
+
+// nodemesh implements the configType interface.
+type nodemesh struct {
+	c client.ConfigInterface
+}
+
+func (n nodemesh) set(value, node string) error {
+	if node != "" {
+		return errors.New("--node should not be specified")
+	}
+	
+	switch value {
+	case "on":
+		return n.c.SetNodeToNodeMesh(true)
+	case "off":
+		return n.c.SetNodeToNodeMesh(false)
+	default:
+		return errors.New("invalid value '" + value + "'")
+	}
+}
+
+func (n nodemesh) unset(node string) error {
+	if node != "" {
+		return errors.New("--node should not be specified")
+	}
+
+	return n.c.SetNodeToNodeMesh(client.GlobalDefaultNodeToNodeMesh)
+}
+
+func (n nodemesh) view(node string) error {
+	if node != "" {
+		return errors.New("--node should not be specified")
+	}
+	
+	enabled, err := n.c.GetNodeToNodeMesh()
+	if err != nil {
+		return err
+	}
+	if enabled {
+		fmt.Println("on")
+	} else {
+		fmt.Println("off")
+	}
+	return nil
+}
+
+
+// ipip implements the configType interface.
+type ipip struct {
+	c client.ConfigInterface
+}
+
+func (i ipip) set(value, node string) error {
+	if node != "" {
+		return errors.New("--node should not be specified")
+	}
+	
+	switch value {
+	case "on":
+		return i.c.SetGlobalIPIP(true)
+	case "off":
+		return i.c.SetGlobalIPIP(false)
+	default:
+		return errors.New("invalid value '" + value + "'")
+	}
+}
+
+func (i ipip) unset(node string) error {
+	if node != "" {
+		return errors.New("--node should not be specified")
+	}
+
+	return i.c.SetGlobalIPIP(client.GlobalDefaultIPIP)
+}
+
+func (i ipip) view(node string) error {
+	if node != "" {
+		return errors.New("--node should not be specified")
+	}
+	
+	enabled, err := i.c.GetGlobalIPIP()
+	if err != nil {
+		return err
+	}
+	if enabled {
+		fmt.Println("on")
+	} else {
+		fmt.Println("off")
+	}
+	return nil
+}
+
+// asnum implements the configType interface.
+type asnum struct {
+	c client.ConfigInterface
+}
+
+
+func (a asnum) set(value, node string) error {
+	if node != "" {
+		return errors.New("--node should not be specified")
+	}
+
+	asn, err := strconv.ParseUint(value, 10, 64)
+	if err != nil {
+		return err
+	}
+
+	return a.c.SetGlobalASNumber(asn)
+}
+
+func (a asnum) unset(node string) error {
+	if node != "" {
+		return errors.New("--node should not be specified")
+	}
+
+	return a.c.SetGlobalASNumber(client.GlobalDefaultASNumber)
+}
+
+func (a asnum) view(node string) error {
+	if node != "" {
+		return errors.New("--node should not be specified")
+	}
+
+	asn, err := a.c.GetGlobalASNumber()
+	if err != nil {
+		return err
+	}
+	fmt.Println(asn)
+	return nil
+}

--- a/calicoctl/commands/constants/help.go
+++ b/calicoctl/commands/constants/help.go
@@ -15,7 +15,7 @@
 package constants
 
 const (
-	DatastoreIntro = `Set the Calico datastore access information in the environment variables
+	DatastoreIntro = `Set the Calico datastore access information in the environment variables or
 or supply details in a config file.
 
 `

--- a/calicoctl/commands/create.go
+++ b/calicoctl/commands/create.go
@@ -38,29 +38,33 @@ Examples:
 
 Options:
   -h --help                 Show this screen.
-  -f --filename=<FILENAME>  Filename to use to create the resource.  If set to "-" loads from stdin.
-  -s --skip-exists          Skip over and treat as successful any attempts to create an entry that
-                            already exists.
-  -c --config=<CONFIG>      Filename containing connection configuration in YAML or JSON format.
+  -f --filename=<FILENAME>  Filename to use to create the resource.  If set to
+                            "-" loads from stdin.
+     --skip-exists          Skip over and treat as successful any attempts to
+                            create an entry that already exists.
+  -c --config=<CONFIG>      Filename containing connection configuration in
+                            YAML or JSON format.
                             [default: /etc/calico/calicoctl.cfg]
 
 Description:
-  The create command is used to create a set of resources by filename or stdin.  JSON and
-  YAML formats are accepted.
+  The create command is used to create a set of resources by filename or stdin.
+  JSON and YAML formats are accepted.
 
-  Valid resource types are node, bgpPeer, hostEndpoint, workloadEndpoint, policy, pool and
-  profile.
+  Valid resource types are node, bgpPeer, hostEndpoint, workloadEndpoint, pool,
+  policy, and profile.
 
-  Attempting to create a resource that already exists is treated as a terminating error unless the
-  --skip-exists flag is set.  If this flag is set, resources that already exist are skipped.
+  Attempting to create a resource that already exists is treated as a
+  terminating error unless the --skip-exists flag is set.  If this flag is set,
+  resources that already exist are skipped.
 
-  The output of the command indicates how many resources were successfully created, and the error
-  reason if an error occurred.  If the --skip-exists flag is set then skipped resources are
-  included in the success count.
+  The output of the command indicates how many resources were successfully
+  created, and the error reason if an error occurred.  If the --skip-exists
+  flag is set then skipped resources are included in the success count.
 
-  The resources are created in the order they are specified.  In the event of a failure
-  creating a specific resource it is possible to work out which resource failed based on the
-  number of resources successfully created.`
+  The resources are created in the order they are specified.  In the event of a
+  failure creating a specific resource it is possible to work out which
+  resource failed based on the number of resources successfully created.
+`
 	parsedArgs, err := docopt.Parse(doc, args, true, "", false, false)
 	if err != nil {
 		fmt.Printf("Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.\n", strings.Join(args, " "))

--- a/calicoctl/commands/delete.go
+++ b/calicoctl/commands/delete.go
@@ -27,9 +27,9 @@ import (
 
 func Delete(args []string) {
 	doc := constants.DatastoreIntro + `Usage:
-  calicoctl delete ([--node=<NODE>] [--orchestrator=<ORCH>] [--workload=<WORKLOAD>] [--scope=<SCOPE>]
-                    (<KIND> [<NAME>]) |
-                    --filename=<FILE>)
+  calicoctl delete ([--scope=<SCOPE>] [--node=<NODE>] [--orchestrator=<ORCH>]
+                    [--workload=<WORKLOAD>] (<KIND> [<NAME>]) |
+                   --filename=<FILE>)
                    [--skip-not-exists] [--config=<CONFIG>]
 
 Examples:
@@ -44,39 +44,47 @@ Examples:
 
 Options:
   -h --help                 Show this screen.
-  -s --skip-not-exists      Skip over and treat as successful, resources that don't exist.
-  -f --filename=<FILENAME>  Filename to use to delete the resource.  If set to "-" loads from stdin.
-  -n --node=<NODE>          The node (this may be the hostname of the compute server if your
-                            installation does not explicitly set the names of each Calico node).
-     --orchestrator=<ORCH>  The orchestrator (only used for workload endpoints).
-     --workload=<WORKLOAD>  The workload (only used for workload endpoints).
-  --scope=<SCOPE>           The scope of the resource type.  One of global, node.  This is only valid
-                            for BGP peers and is used to indicate whether the peer is a global peer
-                            or node-specific.
-  -c --config=<CONFIG>      Filename containing connection configuration in YAML or JSON format.
+  -s --skip-not-exists      Skip over and treat as successful, resources that
+                            don't exist.
+  -f --filename=<FILENAME>  Filename to use to delete the resource.  If set to
+                            "-" loads from stdin.
+  -n --node=<NODE>          The node (this may be the hostname of the compute
+                            server if your installation does not explicitly set
+                            the names of each Calico node).
+     --orchestrator=<ORCH>  The orchestrator (valid for workload endpoints).
+     --workload=<WORKLOAD>  The workload (valid for workload endpoints).
+     --scope=<SCOPE>        The scope of the resource type.  One of global,
+                            node.  This is only valid for BGP peers and is used
+                            to indicate whether the peer is a global peer or
+                            node-specific.
+  -c --config=<CONFIG>      Filename containing connection configuration in
+                            YAML or JSON format.
                             [default: /etc/calico/calicoctl.cfg]
 
 Description:
-  The delete command is used to delete a set of resources by filename or stdin, or
-  by type and identifiers.  JSON and YAML formats are accepted for file and stdin format.
+  The delete command is used to delete a set of resources by filename or stdin,
+  or by type and identifiers.  JSON and YAML formats are accepted for file and
+  stdin format.
 
-  Valid resource types are node, bgpPeer, hostEndpoint, workloadEndpoint, policy, pool and
-  profile.  The <TYPE> is case insensitive and may be pluralized.
+  Valid resource types are node, bgpPeer, hostEndpoint, workloadEndpoint, pool
+  policy, and profile.  The <TYPE> is case insensitive and may be pluralized.
 
-  Attempting to delete a resource that does not exists is treated as a terminating error unless the
-  --skip-not-exists flag is set.  If this flag is set, resources that do not exist are skipped.
+  Attempting to delete a resource that does not exists is treated as a
+  terminating error unless the --skip-not-exists flag is set.  If this flag is
+  set, resources that do not exist are skipped.
 
-  When deleting resources by type, only a single type may be specified at a time.  The name
-  is required along with any and other identifiers required to uniquely identify a resource of the
-  specified type.
+  When deleting resources by type, only a single type may be specified at a
+  time.  The name is required along with any and other identifiers required to
+  uniquely identify a resource of the specified type.
 
-  The output of the command indicates how many resources were successfully deleted, and the error
-  reason if an error occurred.  If the --skip-not-exists flag is set then skipped resources are
-  included in the success count.
+  The output of the command indicates how many resources were successfully
+  deleted, and the error reason if an error occurred.  If the --skip-not-exists
+  flag is set then skipped resources are included in the success count.
 
-  The resources are deleted in the order they are specified.  In the event of a failure
-  deleting a specific resource it is possible to work out which resource failed based on the
-  number of resources successfully deleted.`
+  The resources are deleted in the order they are specified.  In the event of a
+  failure deleting a specific resource it is possible to work out which
+  resource failed based on the number of resources successfully deleted.
+`
 	parsedArgs, err := docopt.Parse(doc, args, true, "", false, false)
 	if err != nil {
 		fmt.Printf("Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.\n", strings.Join(args, " "))

--- a/calicoctl/commands/get.go
+++ b/calicoctl/commands/get.go
@@ -28,9 +28,9 @@ import (
 
 func Get(args []string) {
 	doc := constants.DatastoreIntro + `Usage:
-  calicoctl get ([--node=<NODE>] [--orchestrator=<ORCH>] [--workload=<WORKLOAD>] [--scope=<SCOPE>]
-                 (<KIND> [<NAME>]) |
-                 --filename=<FILENAME>)
+  calicoctl get ([--scope=<SCOPE>] [--node=<NODE>] [--orchestrator=<ORCH>]
+                 [--workload=<WORKLOAD>] (<KIND> [<NAME>]) |
+                --filename=<FILENAME>)
                 [--output=<OUTPUT>] [--config=<CONFIG>]
 
 Examples:
@@ -42,52 +42,64 @@ Examples:
 
 Options:
   -h --help                    Show this screen.
-  -f --filename=<FILENAME>     Filename to use to get the resource.  If set to "-" loads from stdin.
-  -o --output=<OUTPUT FORMAT>  Output format.  One of: ps, wide, custom-columns=..., yaml, json,
-                               go-template=..., go-template-file=...   [Default: ps]
-  -n --node=<NODE>             The node (this may be the hostname of the compute server if your
-                               installation does not explicitly set the names of each Calico node).
-     --orchestrator=<ORCH>     The orchestrator (only used for workload endpoints).
-     --workload=<WORKLOAD>     The workload (only used for workload endpoints).
-  --scope=<SCOPE>              The scope of the resource type.  One of global, node.  This is only valid
-                               for BGP peers and is used to indicate whether the peer is a global peer
-                               or node-specific.
-  -c --config=<CONFIG>         Filename containing connection configuration in YAML or JSON format.
+  -f --filename=<FILENAME>     Filename to use to get the resource.  If set to
+                               "-" loads from stdin.
+  -o --output=<OUTPUT FORMAT>  Output format.  One of: yaml, json, ps, wide,
+                               custom-columns=..., go-template=...,
+                               go-template-file=...   [Default: ps]
+  -n --node=<NODE>             The node (this may be the hostname of the
+                               compute server if your installation does not
+                               explicitly set the names of each Calico node).
+     --orchestrator=<ORCH>     The orchestrator (valid for workload endpoints).
+     --workload=<WORKLOAD>     The workload (valid for workload endpoints).
+     --scope=<SCOPE>           The scope of the resource type.  One of global,
+                               node.  This is only valid for BGP peers and is
+                               used to indicate whether the peer is a global
+                               peer or node-specific.
+  -c --config=<CONFIG>         Filename containing connection configuration in
+                               YAML or JSON format.
                                [default: /etc/calico/calicoctl.cfg]
 
 Description:
-  The get command is used to display a set of resources by filename or stdin, or by type and
-  identifiers.  JSON and YAML formats are accepted for file and stdin format.
+  The get command is used to display a set of resources by filename or stdin,
+  or by type and identifiers.  JSON and YAML formats are accepted for file and
+  stdin format.
 
-  Valid resource types are node, bgpPeer, hostEndpoint, workloadEndpoint, policy, pool and
-  profile.  The <TYPE> is case insensitive and may be pluralized.
+  Valid resource types are node, bgpPeer, hostEndpoint, workloadEndpoint, pool,
+  policy and profile.  The <TYPE> is case insensitive and may be pluralized.
 
   Attempting to get resources that do not exist will simply return no results.
 
-  When getting resources by type, only a single type may be specified at a time.  The name
-  and other identifiers (hostname, scope) are optional, and are wildcarded when omitted.
-  Thus if you specify no identifiers at all (other than type), then all configured resources of
-  the requested type will be returned.
+  When getting resources by type, only a single type may be specified at a
+  time.  The name and other identifiers (hostname, scope) are optional, and are
+  wildcarded when omitted. Thus if you specify no identifiers at all (other
+  than type), then all configured resources of the requested type will be
+  returned.
 
-  By default the results are output in a ps-style table output.  There are alternative ways to
-  display the data using the --output option:
+  By default the results are output in a ps-style table output.  There are
+  alternative ways to display the data using the --output option:
+
     ps                    Display the results in ps-style output.
     wide                  As per the ps option, but includes more headings.
-    custom-columns        As per the ps option, but only display the columns that are requested
-                          in the comma serarated list.
-    golang-template       Display the results using the specified golang template.  This can be
-                          used to filter results to, say, return a specific value.
-    golang-template-file  Display the results using the golang template that is contained in the
-                          specified file.
+    custom-columns        As per the ps option, but only display the columns
+                          that are requested in the comma-separated list.
+    golang-template       Display the results using the specified golang
+                          template.  This can be used to filter results, for
+                          example to return a specific value.
+    golang-template-file  Display the results using the golang template that is
+                          contained in the specified file.
     yaml                  Display the results in YAML output format.
     json                  Display the results in JSON output format.
 
-  Note that the data output using YAML or JSON format is always valid to use as input to all of the
-  resource management commands (create, apply, replace, delete, get).
+  Note that the data output using YAML or JSON format is always valid to use as
+  input to all of the resource management commands (create, apply, replace,
+  delete, get).
 
-  Please refer to the docs at http://docs.projectcalico.org for more details on the output formats,
-  including example outputs, resource structure (required for the golang template definitions) and
-  the valid column names (required for the custom-columns option).`
+  Please refer to the docs at http://docs.projectcalico.org for more details on
+  the output formats, including example outputs, resource structure (required
+  for the golang template definitions) and the valid column names (required for
+  the custom-columns option).
+`
 	parsedArgs, err := docopt.Parse(doc, args, true, "", false, false)
 	if err != nil {
 		fmt.Printf("Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.\n", strings.Join(args, " "))

--- a/calicoctl/commands/ipam.go
+++ b/calicoctl/commands/ipam.go
@@ -29,17 +29,18 @@ func IPAM(args []string) {
 	doc := constants.DatastoreIntro + `Usage:
   calicoctl ipam <command> [<args>...]
 
-    release       Release a Calico assigned IP address.
-    show          Show details of a Calico assigned IP address.
+    release      Release a Calico assigned IP address.
+    show         Show details of a Calico assigned IP address.
 
 Options:
-  -h --help               Show this screen.
+  -h --help      Show this screen.
 
 Description:
   IP Address Management specific commands for calicoctl.
 
-  See 'calicoctl ipam <command> --help' to read about a specific subcommand.`
-	arguments, err := docopt.Parse(doc, args, true, "", true, false)
+  See 'calicoctl ipam <command> --help' to read about a specific subcommand.
+`
+	arguments, err := docopt.Parse(doc, args, true, "", false, false)
 	if err != nil {
 		fmt.Printf("Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.\n", strings.Join(args, " "))
 		os.Exit(1)

--- a/calicoctl/commands/ipam/release.go
+++ b/calicoctl/commands/ipam/release.go
@@ -32,10 +32,10 @@ func Release(args []string) {
   calicoctl ipam release --ip=<IP> [--config=<CONFIG>]
 
 Options:
-  -h --help                 Show this screen.
-     --ip=<IP>              IP address
-  -c --config=<CONFIG>      Filename containing connection configuration in YAML or JSON format.
-                            [default: /etc/calico/calicoctl.cfg]
+  -h --help             Show this screen.
+     --ip=<IP>          IP address to release.
+  -c --config=<CONFIG>  Filename containing connection configuration in YAML or
+                        JSON format. [default: /etc/calico/calicoctl.cfg]
 
 Description:
   The ipam release command releases an IP address from the Calico IP Address
@@ -44,8 +44,8 @@ Description:
 
   Note that this does not remove the IP from any existing endpoints that may be
   using it, so only use this command to clean up addresses from endpoints that
-  were not cleanly removed from Calico.`
-
+  were not cleanly removed from Calico.
+`
 	parsedArgs, err := docopt.Parse(doc, args, true, "", false, false)
 	if err != nil {
 		fmt.Printf("Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.\n", strings.Join(args, " "))
@@ -60,6 +60,7 @@ Description:
 	client, err := clientmgr.NewClient(cf)
 	if err != nil {
 		fmt.Println(err)
+		os.Exit(1)
 	}
 
 	ipamClient := client.IPAM()

--- a/calicoctl/commands/ipam/show.go
+++ b/calicoctl/commands/ipam/show.go
@@ -32,16 +32,16 @@ func Show(args []string) {
   calicoctl ipam show --ip=<IP> [--config=<CONFIG>]
 
 Options:
-  -h --help                 Show this screen.
-     --ip=<IP>              IP address
-  -c --config=<CONFIG>      Filename containing connection configuration in YAML or JSON format.
-                            [default: /etc/calico/calicoctl.cfg]
+  -h --help             Show this screen.
+     --ip=<IP>          IP address to show.
+  -c --config=<CONFIG>  Filename containing connection configuration in YAML or
+                        JSON format. [default: /etc/calico/calicoctl.cfg]
 
 Description:
-  The ipam show command prints information about a given IP address, such as special
-  attributes defined for the IP or whether the IP has been reserved by a user of
-  the Calico IP Address Manager.`
-
+  The ipam show command prints information about a given IP address, such as
+  special attributes defined for the IP or whether the IP has been reserved by
+  a user of the Calico IP Address Manager.
+`
 	parsedArgs, err := docopt.Parse(doc, args, true, "", false, false)
 	if err != nil {
 		fmt.Printf("Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.\n", strings.Join(args, " "))
@@ -56,6 +56,7 @@ Description:
 	client, err := clientmgr.NewClient(cf)
 	if err != nil {
 		fmt.Println(err)
+		os.Exit(1)
 	}
 
 	ipamClient := client.IPAM()

--- a/calicoctl/commands/node.go
+++ b/calicoctl/commands/node.go
@@ -30,19 +30,20 @@ func Node(args []string) {
 	doc := constants.DatastoreIntro + `Usage:
   calicoctl node <command> [<args>...]
 
-    status         View the current status of a Calico node.
-    diags          Gather a diagnostics bundle for a Calico node.
-    checksystem    Verify the compute host is able to run a Calico node instance.
+    status       View the current status of a Calico node.
+    diags        Gather a diagnostics bundle for a Calico node.
+    checksystem  Verify the compute host is able to run a Calico node instance.
 
 Options:
-  -h --help               Show this screen.
+  -h --help      Show this screen.
 
 Description:
   Node specific commands for calicoctl.  These commands must be run directly on
   the compute host running the Calico node instance.
   
-  See 'calicoctl node <command> --help' to read about a specific subcommand.`
-	arguments, err := docopt.Parse(doc, args, true, "", true, false)
+  See 'calicoctl node <command> --help' to read about a specific subcommand.
+`
+	arguments, err := docopt.Parse(doc, args, true, "", false, false)
 	if err != nil {
 		fmt.Printf("Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.\n", strings.Join(args, " "))
 		os.Exit(1)

--- a/calicoctl/commands/replace.go
+++ b/calicoctl/commands/replace.go
@@ -39,28 +39,32 @@ Examples:
 
 Options:
   -h --help                  Show this screen.
-  -f --filename=<FILENAME>   Filename to use to replace the resource.  If set to "-" loads from stdin.
-  -c --config=<CONFIG>       Filename containing connection configuration in YAML or JSON format.
+  -f --filename=<FILENAME>   Filename to use to replace the resource.  If set
+                             to "-" loads from stdin.
+  -c --config=<CONFIG>       Filename containing connection configuration in
+                             YAML or JSON format.
                              [default: /etc/calico/calicoctl.cfg]
 
 Description:
-  The replace command is used to replace a set of resources by filename or stdin.  JSON and
-  YAML formats are accepted.
+  The replace command is used to replace a set of resources by filename or
+  stdin.  JSON and YAML formats are accepted.
 
-  Valid resource types are node, bgpPeer, hostEndpoint, workloadEndpoint, policy, pool and
-  profile.
+  Valid resource types are node, bgpPeer, hostEndpoint, workloadEndpoint, pool,
+  policy, and profile.
 
-  Attempting to replace a resource that does not exist is treated as a terminating error.
+  Attempting to replace a resource that does not exist is treated as a
+  terminating error.
 
-  The output of the command indicates how many resources were successfully replaced, and the error
-  reason if an error occurred.
+  The output of the command indicates how many resources were successfully
+  eplaced, and the error reason if an error occurred.
 
-  The resources are replaced in the order they are specified.  In the event of a failure
-  replacing a specific resource it is possible to work out which resource failed based on the
-  number of resources successfully replaced.
+  The resources are replaced in the order they are specified.  In the event of
+  a failure replacing a specific resource it is possible to work out which
+  resource failed based on the number of resources successfully replaced.
 
-  When replacing a resource, the complete resource spec must be provided, it is not sufficient
-  to supply only the fields that are being updated.`
+  When replacing a resource, the complete resource spec must be provided, it is
+  not sufficient to supply only the fields that are being updated.
+`
 	parsedArgs, err := docopt.Parse(doc, args, true, "", false, false)
 	if err != nil {
 		fmt.Printf("Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.\n", strings.Join(args, " "))

--- a/calicoctl/commands/resources.go
+++ b/calicoctl/commands/resources.go
@@ -100,6 +100,12 @@ func getResourceFromArguments(args map[string]interface{}) (unversioned.Resource
 	orchestrator := argStringOrBlank(args, "--orchestrator")
 	resScope := argStringOrBlank(args, "--scope")
 	switch strings.ToLower(kind) {
+	case "nodes":
+		fallthrough
+	case "node":
+		p := api.NewNode()
+		p.Metadata.Name = name
+		return *p, nil
 	case "hostendpoints":
 		fallthrough
 	case "hostendpoint":

--- a/calicoctl/commands/resources.go
+++ b/calicoctl/commands/resources.go
@@ -100,43 +100,31 @@ func getResourceFromArguments(args map[string]interface{}) (unversioned.Resource
 	orchestrator := argStringOrBlank(args, "--orchestrator")
 	resScope := argStringOrBlank(args, "--scope")
 	switch strings.ToLower(kind) {
-	case "nodes":
-		fallthrough
-	case "node":
+	case "node", "nodes":
 		p := api.NewNode()
 		p.Metadata.Name = name
 		return *p, nil
-	case "hostendpoints":
-		fallthrough
-	case "hostendpoint":
+	case "hostendpoint", "hostendpoints":
 		h := api.NewHostEndpoint()
 		h.Metadata.Name = name
 		h.Metadata.Node = node
 		return *h, nil
-	case "workloadendpoints":
-		fallthrough
-	case "workloadendpoint":
+	case "workloadendpoint", "workloadendpoints":
 		h := api.NewWorkloadEndpoint()
 		h.Metadata.Name = name
 		h.Metadata.Orchestrator = orchestrator
 		h.Metadata.Workload = workload
 		h.Metadata.Node = node
 		return *h, nil
-	case "profiles":
-		fallthrough
-	case "profile":
+	case "profile", "profiles":
 		p := api.NewProfile()
 		p.Metadata.Name = name
 		return *p, nil
-	case "policies":
-		fallthrough
-	case "policy":
+	case "policy", "policies":
 		p := api.NewPolicy()
 		p.Metadata.Name = name
 		return *p, nil
-	case "pools":
-		fallthrough
-	case "pool":
+	case "pool", "pools":
 		p := api.NewPool()
 		if name != "" {
 			_, cidr, err := net.ParseCIDR(name)
@@ -146,9 +134,7 @@ func getResourceFromArguments(args map[string]interface{}) (unversioned.Resource
 			p.Metadata.CIDR = *cidr
 		}
 		return *p, nil
-	case "bgppeers":
-		fallthrough
-	case "bgppeer":
+	case "bgppeer", "bgppeers":
 		p := api.NewBGPPeer()
 		if name != "" {
 			err := p.Metadata.PeerIP.UnmarshalText([]byte(name))

--- a/calicoctl/commands/version.go
+++ b/calicoctl/commands/version.go
@@ -37,7 +37,8 @@ Options:
   -h --help   Show this screen.
 
 Description:
-  Display the version of calicoctl.`
+  Display the version of calicoctl.
+`
 	arguments, err := docopt.Parse(doc, args, true, "", false, false)
 	if err != nil {
 		fmt.Printf("Invalid option: 'calicoctl %s'. Use flag '--help' to read about a specific subcommand.\n", strings.Join(args, " "))

--- a/calicoctl/resourcemgr/node.go
+++ b/calicoctl/resourcemgr/node.go
@@ -28,7 +28,7 @@ func init() {
 		[]string{"NAME", "ASN", "IPV4", "IPV6"},
 		map[string]string{
 			"NAME": "{{.Metadata.Name}}",
-			"ASN": "{{if .Spec.BGP}}{{.Spec.BGP.ASNumber}}{{end}}",
+			"ASN":  "{{if .Spec.BGP}}{{.Spec.BGP.ASNumber}}{{end}}",
 			"IPV4": "{{if .Spec.BGP}}{{.Spec.BGP.IPv4Address}}{{end}}",
 			"IPV6": "{{if .Spec.BGP}}{{.Spec.BGP.IPv6Address}}{{end}}",
 		},

--- a/calicoctl/resourcemgr/node.go
+++ b/calicoctl/resourcemgr/node.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourcemgr
+
+import (
+	"github.com/projectcalico/libcalico-go/lib/api"
+	"github.com/projectcalico/libcalico-go/lib/api/unversioned"
+	"github.com/projectcalico/libcalico-go/lib/client"
+)
+
+func init() {
+	registerResource(
+		api.NewNode(),
+		api.NewNodeList(),
+		[]string{"NAME"},
+		[]string{"NAME", "ASN", "IPV4", "IPV6"},
+		map[string]string{
+			"NAME": "{{.Metadata.Name}}",
+			"ASN": "{{if .Spec.BGP}}{{.Spec.BGP.ASNumber}}{{end}}",
+			"IPV4": "{{if .Spec.BGP}}{{.Spec.BGP.IPv4Address}}{{end}}",
+			"IPV6": "{{if .Spec.BGP}}{{.Spec.BGP.IPv6Address}}{{end}}",
+		},
+		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+			r := resource.(api.Node)
+			return client.Nodes().Apply(&r)
+		},
+		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+			r := resource.(api.Node)
+			return client.Nodes().Create(&r)
+		},
+		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+			r := resource.(api.Node)
+			return client.Nodes().Update(&r)
+		},
+		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+			r := resource.(api.Node)
+			return nil, client.Nodes().Delete(r.Metadata)
+		},
+		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+			r := resource.(api.Node)
+			return client.Nodes().List(r.Metadata)
+		},
+	)
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
 hash: 148e2e335fe5f25a6ba24c8fef221c3be382ffbdd6d757ab36c69bbeb2a68b51
-updated: 2016-10-20T15:42:13.536406931+01:00
+updated: 2016-11-01T17:41:15.217791692Z
 imports:
 - name: github.com/coreos/etcd
-  version: 6b1b13eabb6b6b6e07867c496451696c64a8117d
+  version: db83736b7b222ffe55dfacbcfea13395019a71a9
   subpackages:
   - client
   - pkg/fileutil
@@ -37,7 +37,7 @@ imports:
 - name: github.com/olekukonko/tablewriter
   version: bdcc175572fd7abece6c831e643891b9331bc9e7
 - name: github.com/projectcalico/libcalico-go
-  version: 2fb2aca8785016c3440491e7452adb0309303c11
+  version: 72934becad2115a5fa2178c9a46564358b4554e0
   subpackages:
   - lib
   - lib/api
@@ -69,11 +69,11 @@ imports:
   subpackages:
   - codec
 - name: golang.org/x/net
-  version: daba796358cd2742b75aae05761f1b898c9f6a5c
+  version: 541150ac4f433e755f5663eba5d888c2fa347343
   subpackages:
   - context
 - name: golang.org/x/sys
-  version: 002cbb5f952456d0c50e0d2aff17ea5eca716979
+  version: c200b10b5d5e122be351b67af224adc6128af5bf
   subpackages:
   - unix
 - name: gopkg.in/go-playground/validator.v8
@@ -86,7 +86,7 @@ imports:
   version: a5b47d31c556af34a302ce5d659e6fea44d90de0
 testImports:
 - name: github.com/onsi/ginkgo
-  version: 39549e585f5005ce588e6217d4538a4c99a472c9
+  version: a8ccd817611666211fdf6e6a752174a0db8374a8
   subpackages:
   - config
   - internal/codelocation
@@ -105,7 +105,7 @@ testImports:
   - reporters/stenographer/support/go-isatty
   - types
 - name: github.com/onsi/gomega
-  version: d59fa0ac68bb5dd932ee8d24eed631cdd519efc3
+  version: ff4bc6b6f9f5affa66635cd04d31d2a7ee21ffd6
   subpackages:
   - format
   - internal/assertion

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
 hash: 148e2e335fe5f25a6ba24c8fef221c3be382ffbdd6d757ab36c69bbeb2a68b51
-updated: 2016-11-01T17:41:15.217791692Z
+updated: 2016-11-02T11:50:16.526307186Z
 imports:
 - name: github.com/coreos/etcd
-  version: db83736b7b222ffe55dfacbcfea13395019a71a9
+  version: 5b7728f3cb1df4aa8b66e07de1bd5df484bc8e35
   subpackages:
   - client
   - pkg/fileutil
@@ -37,7 +37,7 @@ imports:
 - name: github.com/olekukonko/tablewriter
   version: bdcc175572fd7abece6c831e643891b9331bc9e7
 - name: github.com/projectcalico/libcalico-go
-  version: 72934becad2115a5fa2178c9a46564358b4554e0
+  version: 45e13d19f33baed6bbb884486465047d64ae0022
   subpackages:
   - lib
   - lib/api
@@ -69,7 +69,7 @@ imports:
   subpackages:
   - codec
 - name: golang.org/x/net
-  version: 541150ac4f433e755f5663eba5d888c2fa347343
+  version: 4bb47a1098b37d69980d96237e2ae4ff56bb5a95
   subpackages:
   - context
 - name: golang.org/x/sys

--- a/test/host.yaml
+++ b/test/host.yaml
@@ -1,0 +1,13 @@
+- apiVersion: v1
+  kind: node
+  metadata:
+    name: node1
+- apiVersion: v1
+  kind: node
+  metadata:
+    name: node2
+  spec:
+    bgp:
+      asNumber: 12345
+      ipv4Address: 1.2.3.4
+      ipv6Address: aa::ff


### PR DESCRIPTION
This PR adds:
-  Node as a resource
-  System wide configuration options (and low level node configuration options).

It's possible that we'll make config a "resource" as well and that some of the node-specific config options could move into the node resource - but I think that can be done later with pretty minor deprecation and phase out.

I've also gone through the various command line helps and fixed the width at 79 characters because it was too long and uneven.  Should make our docs nicer once I cut and paste it into our docs.