### PR TITLE
libcalico is no longer requered for node image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,6 @@ BUILD_CONTAINER_NAME?=calico/build:v0.18.0
 NODE_CONTAINER_DIR=calico_node
 NODE_CONTAINER_NAME?=calico/node:$(CALICOCONTAINERS_VERSION)
 NODE_CONTAINER_FILES=$(shell find $(NODE_CONTAINER_DIR)/filesystem -type f)
-# we can pass --build-arg during node image building
-NODE_CONTAINER_BUILD_ARGS?=
 NODE_CONTAINER_CREATED=$(NODE_CONTAINER_DIR)/.calico_node.created
 NODE_CONTAINER_BIN_DIR=$(NODE_CONTAINER_DIR)/filesystem/bin
 NODE_CONTAINER_BINARIES=startup allocate-ipip-addr calico-felix bird calico-bgp-daemon confd libnetwork-plugin
@@ -52,7 +50,7 @@ calico-node-latest.aci: calico-node.tar
 
 # Build calico/node docker image - explicitly depend on the container binaries.
 $(NODE_CONTAINER_CREATED): $(NODE_CONTAINER_DIR)/Dockerfile $(NODE_CONTAINER_FILES) $(addprefix $(NODE_CONTAINER_BIN_DIR)/,$(NODE_CONTAINER_BINARIES))
-	docker build $(NODE_CONTAINER_BUILD_ARGS) -t $(NODE_CONTAINER_NAME) $(NODE_CONTAINER_DIR)
+	docker build -t $(NODE_CONTAINER_NAME) $(NODE_CONTAINER_DIR)
 	touch $@
 
 # Build binary from python files, e.g. startup.py or allocate-ipip-addr.py

--- a/calico_node/Dockerfile
+++ b/calico_node/Dockerfile
@@ -14,7 +14,7 @@
 FROM gliderlabs/alpine:3.4
 MAINTAINER Tom Denham <tom@projectcalico.org>
 
-# Set the minimum Docker API version required for libnetwork. 
+# Set the minimum Docker API version required for libnetwork.
 ENV DOCKER_API_VERSION 1.21
 
 # Download and install glibc for use by non-static binaries that require it.
@@ -32,10 +32,6 @@ RUN apk add --no-cache --repository "http://alpine.gliderlabs.com/alpine/edge/co
 
 # Install remaining runtime deps required for felix from the global repository
 RUN apk add --no-cache ip6tables ipset iputils iproute2 conntrack-tools
-
-# Copy "shared directory" which can be used to pass custom files (local git repos,
-# that can be used by pip install git+file:///)
-COPY node_share /tmp/node_share
 
 # Copy in the filesystem - this contains felix, bird, gobgp etc...
 COPY filesystem /


### PR DESCRIPTION
check related commit: 7d0f4abad31e8e3edc24915aa3efcc546f585345