### PR TITLE
Move to latest libnetwork plugin rc4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ NODE_CONTAINER_CREATED=$(NODE_CONTAINER_DIR)/.calico_node.created
 NODE_CONTAINER_BIN_DIR=$(NODE_CONTAINER_DIR)/filesystem/bin
 NODE_CONTAINER_BINARIES=startup allocate-ipip-addr calico-felix bird calico-bgp-daemon confd libnetwork-plugin
 FELIX_CONTAINER_NAME?=calico/felix:2.0.0-beta.3
-LIBNETWORK_PLUGIN_CONTAINER_NAME?=calico/libnetwork-plugin:v1.0.0-beta-rc3
+LIBNETWORK_PLUGIN_CONTAINER_NAME?=calico/libnetwork-plugin:v1.0.0-beta-rc4
 
 calico/node: $(NODE_CONTAINER_CREATED)    ## Create the calico/node image
 


### PR DESCRIPTION
rc3 doesn't work with non-latest docker.