### PR TITLE
Docker API version for libnetwork

### DIFF
--- a/calico_node/Dockerfile
+++ b/calico_node/Dockerfile
@@ -14,6 +14,9 @@
 FROM gliderlabs/alpine:3.4
 MAINTAINER Tom Denham <tom@projectcalico.org>
 
+# Set the minimum Docker API version required for libnetwork. 
+ENV DOCKER_API_VERSION 1.21
+
 # Download and install glibc for use by non-static binaries that require it.
 RUN apk --no-cache add wget ca-certificates libgcc && \
     wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub && \


### PR DESCRIPTION
should fix this issue with CoreOS:
```bash
core@calico-01 ~ $ docker run --net net1 --name workload-A -tid busybox
452d349d5df743701a337f86bc43e82668c27adede608d2cd502a7312ce8e02e
docker: Error response from daemon: failed to create endpoint workload-A on network net1: NetworkDriver.CreateEndpoint: {"Err":"Network 06efe5384c698245a8290c82353763eac06dc3ec6548c3a3d9ab275ef04adac0 inspection error: Error response from daemon: client is newer than server (client API version: 1.23, server API version: 1.22)"}
null.
```

```
core@calico-01 ~/calico-containers $ docker version
Client:
 Version:      1.10.3
 API version:  1.22
 Go version:   go1.5.4
 Git commit:   1f8f545
 Built:
 OS/Arch:      linux/amd64

Server:
 Version:      1.10.3
 API version:  1.22
 Go version:   go1.5.4
 Git commit:   1f8f545
 Built:
 OS/Arch:      linux/amd64
```