### PR TITLE
Keep CA store after build.  Required by golang felix for usage reporting

### DIFF
--- a/calico_node/Dockerfile
+++ b/calico_node/Dockerfile
@@ -24,7 +24,7 @@ RUN apk --no-cache add wget ca-certificates libgcc && \
     wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.23-r3/glibc-bin-2.23-r3.apk && \
     apk add glibc-2.23-r3.apk glibc-bin-2.23-r3.apk && \
     /usr/glibc-compat/sbin/ldconfig /lib /usr/glibc/usr/lib && \
-    apk del wget ca-certificates && \
+    apk del wget && \
     rm -f glibc-2.23-r3.apk glibc-bin-2.23-r3.apk
 
 # Install runit from the community repository, as its not yet available in global


### PR DESCRIPTION
I think this should be all that's needed but it could do with a retest from @matthewdupre.

Fixes #1276 
Fixes https://github.com/projectcalico/felix/issues/1164