### PR TITLE
Only run the tag related test

### DIFF
--- a/tests/st/test_profile.py
+++ b/tests/st/test_profile.py
@@ -41,14 +41,14 @@ else:
 
 class MultiHostMainline(TestBase):
     @parameterized.expand([
-        "tags",
+        #"tags",
         "rules.tags",
-        "rules.protocol.icmp",
-        "rules.ip.addr",
-        "rules.ip.net",
-        "rules.selector",
-        "rules.tcp.port",
-        "rules.udp.port",
+        #"rules.protocol.icmp",
+        #"rules.ip.addr",
+        #"rules.ip.net",
+        #"rules.selector",
+        #"rules.tcp.port",
+        #"rules.udp.port",
     ])
     def test_multi_host(self, test_type):
         """


### PR DESCRIPTION
Reduce the number of tests that we run in calico-containers