### PR TITLE
Don't display nil when viewing node resources with the --wide option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -353,7 +353,7 @@ $(CTL_CONTAINER_CREATED): Dockerfile.calicoctl dist/calicoctl
 	touch $@
 
 ## Run the build in a container. Useful for CI
-dist/calicoctl: $(BUILD_CALICOCTL_CONTAINER_MARKER) vendor
+dist/calicoctl: $(BUILD_CALICOCTL_CONTAINER_MARKER) $(CALICOCTL_FILES) vendor
 	mkdir -p dist
 	docker run --rm \
 	  -v ${PWD}:/go/src/github.com/projectcalico/calico-containers:ro \

--- a/calicoctl/resourcemgr/node.go
+++ b/calicoctl/resourcemgr/node.go
@@ -28,9 +28,9 @@ func init() {
 		[]string{"NAME", "ASN", "IPV4", "IPV6"},
 		map[string]string{
 			"NAME": "{{.Metadata.Name}}",
-			"ASN":  "{{if .Spec.BGP}}{{.Spec.BGP.ASNumber}}{{end}}",
-			"IPV4": "{{if .Spec.BGP}}{{.Spec.BGP.IPv4Address}}{{end}}",
-			"IPV6": "{{if .Spec.BGP}}{{.Spec.BGP.IPv6Address}}{{end}}",
+			"ASN":  "{{if .Spec.BGP}}{{if .Spec.BGP.ASNumber}}{{.Spec.BGP.ASNumber}}{{end}}{{end}}",
+			"IPV4": "{{if .Spec.BGP}}{{if .Spec.BGP.IPv4Address}}{{.Spec.BGP.IPv4Address}}{{end}}{{end}}",
+			"IPV6": "{{if .Spec.BGP}}{{if .Spec.BGP.IPv6Address}}{{.Spec.BGP.IPv6Address}}{{end}}{{end}}",
 		},
 		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
 			r := resource.(api.Node)


### PR DESCRIPTION
Fixes part of #1271 (but doesn't fix the displaying default ASN when ASN is not specified)

This also fixes the Makefile not rebuilding after changing calicoctl files.