### PR TITLE
Add 'libltdl' library into 'calico/ctl' docker image

### DIFF
--- a/Dockerfile.calicoctl
+++ b/Dockerfile.calicoctl
@@ -5,4 +5,7 @@ ADD dist/calicoctl ./calicoctl
 
 ENV CALICO_CTL_CONTAINER=TRUE
 
+# libltdl.so is needed by docker command line tool
+RUN apk add --no-cache libltdl
+
 ENTRYPOINT ["./calicoctl"]


### PR DESCRIPTION
Closes #1291 