### PR TITLE
calicoctl: do exit(1) if command not found

### DIFF
--- a/calicoctl/calicoctl.go
+++ b/calicoctl/calicoctl.go
@@ -91,7 +91,9 @@ Description:
 		case "config":
 			commands.Config(args)
 		default:
+			fmt.Fprintf(os.Stderr, "Unknown command: %q\n", command)
 			fmt.Println(doc)
+			os.Exit(1)
 		}
 	}
 }


### PR DESCRIPTION
Closes: #1302 

Change-Id: If77775598469afc15cbafda79dc1c18c5aeeabbf