### PR TITLE
Use latest libcalico-go

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 478d26cbe1a1140690242e7dd9fec4bf313d9ba49a2339b54a402c3a4fde4341
-updated: 2016-11-05T22:16:24.100569482-07:00
+hash: 148e2e335fe5f25a6ba24c8fef221c3be382ffbdd6d757ab36c69bbeb2a68b51
+updated: 2016-11-18T10:24:35.318708334-08:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -57,7 +57,7 @@ imports:
   - log
   - swagger
 - name: github.com/ghodss/yaml
-  version: bea76d6a4713e18b7f5321a2b020738552def3ea
+  version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 - name: github.com/go-openapi/jsonpointer
   version: 46af16f9f7b149af66e5d1bd010e3574dc06de98
 - name: github.com/go-openapi/jsonreference
@@ -86,8 +86,6 @@ imports:
   version: 6633656539c1639d9d78127b7d47c622b5d7b6dc
 - name: github.com/jonboulle/clockwork
   version: 2eee05ed794112d45db504eb05aa693efd2b8b09
-- name: github.com/juju/ratelimit
-  version: 77ed1c8a01217656d2080ad51981f6e99adaa177
 - name: github.com/kelseyhightower/envconfig
   version: 9aca109c9aec4633fced9717c4a09ecab3d33111
 - name: github.com/mailru/easyjson
@@ -99,7 +97,7 @@ imports:
 - name: github.com/mattn/go-runewidth
   version: 737072b4e32b7a5018b4a7125da8d12de90e8045
 - name: github.com/mcuadros/go-version
-  version: d52711f8d6bea8dc01efafdb68ad95a4e2606630
+  version: 257f7b9a7d87427c8d7f89469a5958d57f8abd7c
 - name: github.com/mitchellh/go-ps
   version: e2d21980687ce16e58469d98dcee92d27fbbd7fb
 - name: github.com/olekukonko/tablewriter
@@ -107,7 +105,7 @@ imports:
 - name: github.com/pborman/uuid
   version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
 - name: github.com/projectcalico/libcalico-go
-  version: ac7658948424d886ebb34a0205501e74999a482b
+  version: c3038033665942c39cf958a6e145267eb1157ca3
   subpackages:
   - lib
   - lib/api
@@ -167,7 +165,7 @@ imports:
   - jws
   - jwt
 - name: golang.org/x/sys
-  version: 076b546753157f758b316e59bcb51e6807c04057
+  version: 9c60d1c508f5134d1ca726b4641db998f2523357
   subpackages:
   - unix
 - name: golang.org/x/text
@@ -204,9 +202,9 @@ imports:
   subpackages:
   - patricia
 - name: gopkg.in/yaml.v2
-  version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
+  version: a5b47d31c556af34a302ce5d659e6fea44d90de0
 - name: k8s.io/kubernetes
-  version: bc7ae399f8ed2926c89c3ddd64b59fb0377a5c78
+  version: 9d4f94dcec42e9d79b09e0108acc77986c683f02
   subpackages:
   - pkg/api
   - pkg/api/errors
@@ -222,7 +220,7 @@ imports:
   - pkg/apimachinery/registered
   - pkg/apis/apps
   - pkg/apis/apps/install
-  - pkg/apis/apps/v1alpha1
+  - pkg/apis/apps/v1beta1
   - pkg/apis/authentication
   - pkg/apis/authentication/install
   - pkg/apis/authentication/v1beta1
@@ -247,7 +245,7 @@ imports:
   - pkg/apis/extensions/v1beta1
   - pkg/apis/policy
   - pkg/apis/policy/install
-  - pkg/apis/policy/v1alpha1
+  - pkg/apis/policy/v1beta1
   - pkg/apis/rbac
   - pkg/apis/rbac/install
   - pkg/apis/rbac/v1alpha1
@@ -256,17 +254,17 @@ imports:
   - pkg/apis/storage/v1beta1
   - pkg/auth/user
   - pkg/client/clientset_generated/internalclientset
-  - pkg/client/clientset_generated/internalclientset/typed/apps/unversioned
-  - pkg/client/clientset_generated/internalclientset/typed/authentication/unversioned
-  - pkg/client/clientset_generated/internalclientset/typed/authorization/unversioned
-  - pkg/client/clientset_generated/internalclientset/typed/autoscaling/unversioned
-  - pkg/client/clientset_generated/internalclientset/typed/batch/unversioned
-  - pkg/client/clientset_generated/internalclientset/typed/certificates/unversioned
-  - pkg/client/clientset_generated/internalclientset/typed/core/unversioned
-  - pkg/client/clientset_generated/internalclientset/typed/extensions/unversioned
-  - pkg/client/clientset_generated/internalclientset/typed/policy/unversioned
-  - pkg/client/clientset_generated/internalclientset/typed/rbac/unversioned
-  - pkg/client/clientset_generated/internalclientset/typed/storage/unversioned
+  - pkg/client/clientset_generated/internalclientset/typed/apps/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/authentication/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/authorization/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/autoscaling/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/batch/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/certificates/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/core/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/policy/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/storage/internalversion
   - pkg/client/metrics
   - pkg/client/restclient
   - pkg/client/transport
@@ -304,10 +302,12 @@ imports:
   - pkg/util/integer
   - pkg/util/intstr
   - pkg/util/json
+  - pkg/util/jsonpath
   - pkg/util/labels
   - pkg/util/net
   - pkg/util/parsers
   - pkg/util/rand
+  - pkg/util/ratelimit
   - pkg/util/runtime
   - pkg/util/sets
   - pkg/util/uuid
@@ -322,6 +322,7 @@ imports:
   - plugin/pkg/client/auth/gcp
   - plugin/pkg/client/auth/oidc
   - third_party/forked/golang/reflect
+  - third_party/forked/golang/template
 testImports:
 - name: github.com/onsi/ginkgo
   version: 74c678d97c305753605c338c6c78c49ec104b5e7

--- a/glide.yaml
+++ b/glide.yaml
@@ -19,6 +19,5 @@ import:
 - package: github.com/termie/go-shutil
 - package: github.com/mitchellh/go-ps
 - package: github.com/projectcalico/libcalico-go
-  version: 1.0.0-beta
   subpackages:
   - lib

--- a/test-data/all.yaml
+++ b/test-data/all.yaml
@@ -53,8 +53,8 @@
     labels:
       type: database
       THING4: VALUE10/2-F
-  spec:
     tags: [a, b, c, a1, update]
+  spec:
     ingress:
       - action: deny
     egress:

--- a/test-data/policy-icmp-bad.yaml
+++ b/test-data/policy-icmp-bad.yaml
@@ -49,8 +49,8 @@
   kind: profile
   metadata:
     name: profile1
-  spec:
     tags: [a, b, c, a1]
+  spec:
     ingress:
     - action: deny
     egress:

--- a/test-data/policy.yaml
+++ b/test-data/policy.yaml
@@ -43,8 +43,8 @@
   kind: profile
   metadata:
     name: profile1
-  spec:
     tags: [a, b, c, a1]
+  spec:
     ingress:
     - action: deny
     egress:

--- a/test-data/test4.yaml
+++ b/test-data/test4.yaml
@@ -2,7 +2,6 @@
   kind: profile
   metadata:
     name: profile1
-  spec:
     tags:
     - profile1
     labels:

--- a/tests/st/test_calicoctl.py
+++ b/tests/st/test_calicoctl.py
@@ -194,8 +194,11 @@ class TestCreateFromFile(TestBase):
                    }),
         ("profile1", {'apiVersion': 'v1',
                       'kind': 'profile',
-                      'metadata': {'labels': {'foo': 'bar'},
-                                   'name': 'profile1'},
+                      'metadata': {
+                          'labels': {'foo': 'bar'},
+                          'tags': ['tag1', 'tag2s'],
+                          'name': 'profile1'
+                      },
                       'spec': {
                           'egress': [{'action': 'allow',
                                       'destination': {},
@@ -224,10 +227,13 @@ class TestCreateFromFile(TestBase):
                                            'ports': [1234, '10:20'],
                                            'selector': "type=='application'",
                                            'tag': "production"}}],
-                          'tags': ['tag1', 'tag2s']}}),
+                      }}),
         ("profile2", {'apiVersion': 'v1',
                       'kind': 'profile',
-                      'metadata': {'name': 'profile2'},
+                      'metadata': {
+                          'name': 'profile2',
+                          'tags': ['tag1', 'tag2s']
+                      },
                       'spec': {
                           'egress': [{'action': 'allow',
                                       'destination': {},
@@ -236,7 +242,7 @@ class TestCreateFromFile(TestBase):
                                        'action': 'deny',
                                        'destination': {},
                                        'source': {}}],
-                          'tags': ['tag1', 'tag2s']}}),
+                      }}),
     ]
 
     @parameterized.expand(testdata)
@@ -452,7 +458,11 @@ class TestCreateFromFile(TestBase):
         ("profile",
          {'apiVersion': 'v1',
           'kind': 'profile',
-          'metadata': {'labels': {'foo': 'bar'}, 'name': 'profile1'},
+          'metadata': {
+              'labels': {'foo': 'bar'},
+              'name': 'profile1',
+              'tags': ['tag1', 'tag2s']
+          },
           'spec': {
               'egress': [{'action': 'allow',
                           'destination': {},
@@ -480,10 +490,13 @@ class TestCreateFromFile(TestBase):
                                       'ports': [1234, '10:20'],
                                       'selector': "type=='application'",
                                       'tag': "production"}}],
-              'tags': ['tag1', 'tag2s']}},
+              }},
          {'apiVersion': 'v1',
           'kind': 'profile',
-          'metadata': {'name': 'profile2'},
+          'metadata': {
+              'name': 'profile2',
+              'tags': ['tag1', 'tag2s']
+          },
           'spec': {
               'egress': [{'action': 'allow',
                           'destination': {},
@@ -492,7 +505,7 @@ class TestCreateFromFile(TestBase):
                            'action': 'deny',
                            'destination': {},
                            'source': {}}],
-              'tags': ['tag1', 'tag2s']}},
+              }},
          )
     ])
     def test_create_from_file(self, res, data1, data2):
@@ -677,7 +690,11 @@ class TestCreateFromFile(TestBase):
         ("profile",
          {'apiVersion': 'v1',
           'kind': 'profile',
-          'metadata': {'name': 'profile1', 'labels': {'type': 'database'}},
+          'metadata': {
+              'name': 'profile1',
+              'labels': {'type': 'database'},
+              'tags': ['tag1', 'tag2s']
+          },
           'spec': {
               'egress': [{
                   'source': {},
@@ -687,10 +704,14 @@ class TestCreateFromFile(TestBase):
                   'source': {},
                   'destination': {},
                   'action': 'deny'}],
-              'tags': ['a', 'b', 'c', 'a1']}, },
+          }, },
          {'apiVersion': 'v1',
           'kind': 'profile',
-          'metadata': {'labels': {'type': 'frontend'}, 'name': 'profile1'},
+          'metadata': {
+              'labels': {'type': 'frontend'},
+              'name': 'profile1',
+              'tags': ['d', 'e', 'f', 'a1']
+          },
           'spec': {
               'egress': [{
                   'source': {},
@@ -700,7 +721,7 @@ class TestCreateFromFile(TestBase):
                   'source': {},
                   'destination': {},
                   'action': 'deny'}],
-              'tags': ['d', 'e', 'f', 'a1']}},
+              }},
          )
     ])
     def test_apply_create_replace(self, res, data1, data2):
@@ -1002,7 +1023,10 @@ class InvalidData(TestBase):
                                           }),
                    ("profile-icmptype", {'apiVersion': 'v1',
                                          'kind': 'profile',
-                                         'metadata': {'name': 'profile2'},
+                                         'metadata': {
+                                             'name': 'profile2',
+                                             'tags': ['tag1', 'tag2s']
+                                         },
                                          'spec': {
                                              'egress': [{'action': 'allow',
                                                          'destination': {},
@@ -1013,10 +1037,13 @@ class InvalidData(TestBase):
                                                           'action': 'deny',
                                                           'destination': {},
                                                           'source': {}}],
-                                             'tags': ['tag1', 'tag2s']}}),
+                                             }}),
                    ("profile-icmpcode", {'apiVersion': 'v1',
                                          'kind': 'profile',
-                                         'metadata': {'name': 'profile2'},
+                                         'metadata': {
+                                             'name': 'profile2',
+                                             'tags': ['tag1', 'tag2s']
+                                         },
                                          'spec': {
                                              'egress': [{'action': 'allow',
                                                          'destination': {},
@@ -1027,7 +1054,7 @@ class InvalidData(TestBase):
                                                           'action': 'deny',
                                                           'destination': {},
                                                           'source': {}}],
-                                             'tags': ['tag1', 'tag2s']}}),
+                                             }}),
                    ("compound-config", [{
                        'apiVersion': 'v1',
                        'kind': 'bgpPeer',
@@ -1037,7 +1064,10 @@ class InvalidData(TestBase):
                        'spec': {'asNumber': 64511}},
                        {'apiVersion': 'v1',
                         'kind': 'profile',
-                        'metadata': {'name': 'profile2'},
+                        'metadata': {
+                            'name': 'profile2',
+                            'tags': ['tag1', 'tag2s']
+                        },
                         'spec': {
                             'egress': [{'action': 'allow',
                                         'destination': {},
@@ -1048,7 +1078,7 @@ class InvalidData(TestBase):
                                          'action': 'deny',
                                          'destination': {},
                                          'source': {}}],
-                            'tags': ['tag1', 'tag2s']},
+                            },
                         }],
                     ),
                ]

--- a/tests/st/test_profile.py
+++ b/tests/st/test_profile.py
@@ -85,12 +85,12 @@ class MultiHostMainline(TestBase):
             new_profiles = copy.deepcopy(original_profiles)
 
             if test_type == "tags":
-                profile0_tag = new_profiles[0]['spec']['tags'][0]
-                profile1_tag = new_profiles[1]['spec']['tags'][0]
+                profile0_tag = new_profiles[0]['metadata']['tags'][0]
+                profile1_tag = new_profiles[1]['metadata']['tags'][0]
                 # Make a new profiles dict where the two networks have each
                 # other in their tags list
-                new_profiles[0]['spec']['tags'].append(profile1_tag)
-                new_profiles[1]['spec']['tags'].append(profile0_tag)
+                new_profiles[0]['metadata']['tags'].append(profile1_tag)
+                new_profiles[1]['metadata']['tags'].append(profile0_tag)
 
                 self._apply_new_profile(new_profiles, host1)
                 # Check everything can contact everything else now
@@ -98,8 +98,8 @@ class MultiHostMainline(TestBase):
                                          pass_list=n1_workloads + n2_workloads)
 
             elif test_type == "rules.tags":
-                profile0_tag = new_profiles[0]['spec']['tags'][0]
-                profile1_tag = new_profiles[1]['spec']['tags'][0]
+                profile0_tag = new_profiles[0]['metadata']['tags'][0]
+                profile1_tag = new_profiles[1]['metadata']['tags'][0]
                 rule0 = {'action': 'allow',
                          'source':
                              {'tag': profile1_tag}}


### PR DESCRIPTION
In particular this gets:

-  Profile tags moved to Metadata
-  Updated IP pool and Node deletion to remove associated IPAM data