### PR TITLE
do not detect IP addresses on dummy* devices

### DIFF
--- a/calico_node/startup.py
+++ b/calico_node/startup.py
@@ -273,7 +273,7 @@ def main():
 
     # Get IP address of host, if none was specified
     if not ip:
-        ips = get_host_ips(exclude=["^docker.*", "^cbr.*",
+        ips = get_host_ips(exclude=["^docker.*", "^cbr.*", "dummy.*",
                                     "virbr.*", "lxcbr.*", "veth.*",
                                     "cali.*", "tunl.*", "flannel.*"])
         try:


### PR DESCRIPTION
I currently have some devices with the device name matching `dummy*` that I do not want automatically detected. I have a hard time believing someone else would want such a device detected either.