### PR TITLE
add flag to use predefined host ASN

### DIFF
--- a/calico_node/startup.py
+++ b/calico_node/startup.py
@@ -266,7 +266,9 @@ def main():
         sys.exit(1)
 
     as_num = os.getenv("AS")
-    as_num = as_num or None
+    if not as_num:
+        as_num = client.get_host_as(hostname)
+
     if as_num and not validate_asn(as_num):
         print "AS environment (%s) is not a AS number." % as_num
         sys.exit(1)


### PR DESCRIPTION
In some setups, it may be necessary to have peer using different ASNs (for
example when using unique ASN per rack). When the Calico node container starts,
the preconfigured ASN is overwritten and the node is no longer able to peer. By
providing a new environment variable USE_HOST_AS we are able to use the
preconfigured value and survive container restarts.

This is particularly important when using a DaemonSet to deploy the nodes to all
hosts.