### PR TITLE
Add improved error messages and use strict unmarshaling of data

### DIFF
--- a/calicoctl/commands/apply.go
+++ b/calicoctl/commands/apply.go
@@ -81,7 +81,7 @@ Description:
 	log.Infof("results: %+v", results)
 
 	if results.fileInvalid {
-		fmt.Printf("Error processing input file: %v\n", results.err)
+		fmt.Printf("Failed to execute command: %v\n", results.err)
 		os.Exit(1)
 	} else if results.numHandled == 0 {
 		if results.numResources == 0 {

--- a/calicoctl/commands/create.go
+++ b/calicoctl/commands/create.go
@@ -78,7 +78,7 @@ Description:
 	log.Infof("results: %+v", results)
 
 	if results.fileInvalid {
-		fmt.Printf("Error processing input file: %v\n", results.err)
+		fmt.Printf("Failed to execute command: %v\n", results.err)
 		os.Exit(1)
 	} else if results.numHandled == 0 {
 		if results.numResources == 0 {

--- a/calicoctl/commands/delete.go
+++ b/calicoctl/commands/delete.go
@@ -99,7 +99,7 @@ Description:
 	log.Infof("results: %+v", results)
 
 	if results.fileInvalid {
-		fmt.Printf("Error processing input file: %v\n", results.err)
+		fmt.Printf("Failed to execute command: %v\n", results.err)
 		os.Exit(1)
 	} else if results.numHandled == 0 {
 		if results.numResources == 0 {

--- a/calicoctl/commands/get.go
+++ b/calicoctl/commands/get.go
@@ -164,8 +164,11 @@ Description:
 	results := executeConfigCommand(parsedArgs, actionList)
 	log.Infof("results: %+v", results)
 
-	if results.err != nil {
+	if results.fileInvalid {
 		fmt.Printf("Failed to execute command: %v\n", results.err)
+		os.Exit(1)
+	} else if results.err != nil {
+		fmt.Printf("Failed to get resources: %v\n", results.err)
 		os.Exit(1)
 	}
 

--- a/calicoctl/commands/get.go
+++ b/calicoctl/commands/get.go
@@ -165,7 +165,7 @@ Description:
 	log.Infof("results: %+v", results)
 
 	if results.err != nil {
-		fmt.Printf("Error getting resources: %v\n", results.err)
+		fmt.Printf("Failed to execute command: %v\n", results.err)
 		os.Exit(1)
 	}
 

--- a/calicoctl/commands/printer.go
+++ b/calicoctl/commands/printer.go
@@ -21,13 +21,13 @@ import (
 	"strings"
 
 	"bytes"
-	"encoding/json"
 	"os"
 	"text/tabwriter"
 	"text/template"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/ghodss/yaml"
+	"github.com/projectcalico/go-yaml-wrapper"
+	"github.com/projectcalico/go-json/json"
 	"github.com/projectcalico/calico-containers/calicoctl/resourcemgr"
 	"github.com/projectcalico/libcalico-go/lib/api/unversioned"
 )
@@ -174,7 +174,7 @@ func (r resourcePrinterTemplate) print(resources []unversioned.Resource) error {
 }
 
 // join is similar to strings.Join() but takes an arbitrary slice of interfaces and converts
-// each to its string represenation and joins them together with the provided separator
+// each to its string representation and joins them together with the provided separator
 // string.
 func join(items interface{}, separator string) string {
 	// If this is a slice of strings - just use the strings.Join function.

--- a/calicoctl/commands/replace.go
+++ b/calicoctl/commands/replace.go
@@ -78,7 +78,7 @@ Description:
 	log.Infof("results: %+v", results)
 
 	if results.fileInvalid {
-		fmt.Printf("Error processing input file: %v\n", results.err)
+		fmt.Printf("Failed to execute command: %v\n", results.err)
 		os.Exit(1)
 	} else if results.numHandled == 0 {
 		if results.numResources == 0 {

--- a/calicoctl/commands/resources.go
+++ b/calicoctl/commands/resources.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/ghodss/yaml"
+	"github.com/projectcalico/go-yaml-wrapper"
 	"github.com/projectcalico/calico-containers/calicoctl/commands/argutils"
 	"github.com/projectcalico/calico-containers/calicoctl/commands/clientmgr"
 	"github.com/projectcalico/calico-containers/calicoctl/resourcemgr"

--- a/calicoctl/resourcemgr/resourcemgr.go
+++ b/calicoctl/resourcemgr/resourcemgr.go
@@ -29,7 +29,7 @@ import (
 	"bytes"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/ghodss/yaml"
+	"github.com/projectcalico/go-yaml-wrapper"
 	"github.com/projectcalico/libcalico-go/lib/client"
 	"github.com/projectcalico/libcalico-go/lib/validator"
 )
@@ -171,7 +171,7 @@ func unmarshalResource(tm unversioned.TypeMetadata, b []byte) ([]unversioned.Res
 		return nil, err
 	}
 
-	if err = yaml.Unmarshal(b, unpacked); err != nil {
+	if err = yaml.UnmarshalStrict(b, unpacked); err != nil {
 		return nil, err
 	}
 
@@ -202,7 +202,7 @@ func unmarshalSliceOfResources(tml []unversioned.TypeMetadata, b []byte) ([]unve
 		unpacked[i] = r
 	}
 
-	if err := yaml.Unmarshal(b, &unpacked); err != nil {
+	if err := yaml.UnmarshalStrict(b, &unpacked); err != nil {
 		return nil, err
 	}
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 148e2e335fe5f25a6ba24c8fef221c3be382ffbdd6d757ab36c69bbeb2a68b51
-updated: 2016-11-22T22:51:07.640806188-08:00
+hash: e32522a5a5e0d481b1d7e76f217dfd701846af7a8f7062ab6c67998f48ab2b72
+updated: 2016-11-23T19:03:55.831120072-08:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -57,7 +57,7 @@ imports:
   - log
   - swagger
 - name: github.com/ghodss/yaml
-  version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
+  version: a54de18a07046d8c4b26e9327698a2ebb9285b36
 - name: github.com/go-openapi/jsonpointer
   version: 46af16f9f7b149af66e5d1bd010e3574dc06de98
 - name: github.com/go-openapi/jsonreference
@@ -102,10 +102,36 @@ imports:
   version: e2d21980687ce16e58469d98dcee92d27fbbd7fb
 - name: github.com/olekukonko/tablewriter
   version: bdcc175572fd7abece6c831e643891b9331bc9e7
+- name: github.com/onsi/ginkgo
+  version: 74c678d97c305753605c338c6c78c49ec104b5e7
+  subpackages:
+  - config
+  - extensions/table
+  - internal/codelocation
+  - internal/containernode
+  - internal/failer
+  - internal/leafnodes
+  - internal/remote
+  - internal/spec
+  - internal/specrunner
+  - internal/suite
+  - internal/testingtproxy
+  - internal/writer
+  - reporters
+  - reporters/stenographer
+  - types
 - name: github.com/pborman/uuid
   version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
+- name: github.com/projectcalico/go-json
+  version: 52d0fced7a06d33e591e66291b1896f6021d6630
+  subpackages:
+  - json
+- name: github.com/projectcalico/go-yaml
+  version: a24e162d308633fed72ed0ee4fd038570b74e444
+- name: github.com/projectcalico/go-yaml-wrapper
+  version: d8ff4587e9570b667ccc1a4583e3fe9fe3af49e4
 - name: github.com/projectcalico/libcalico-go
-  version: 838a75af2ce9222826c49b76acfa882c697d4886
+  version: ef0ff501cca9fe87dd1580f1f7442884a551dc4b
   subpackages:
   - lib
   - lib/api
@@ -126,6 +152,7 @@ imports:
   - lib/selector
   - lib/selector/parser
   - lib/selector/tokenizer
+  - lib/testutils
   - lib/validator
 - name: github.com/PuerkitoBio/purell
   version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
@@ -165,7 +192,7 @@ imports:
   - jws
   - jwt
 - name: golang.org/x/sys
-  version: 9c60d1c508f5134d1ca726b4641db998f2523357
+  version: 30237cf4eefd639b184d1f2cb77a581ea0be8947
   subpackages:
   - unix
 - name: golang.org/x/text
@@ -204,7 +231,7 @@ imports:
 - name: gopkg.in/yaml.v2
   version: a5b47d31c556af34a302ce5d659e6fea44d90de0
 - name: k8s.io/kubernetes
-  version: 5c918def7a61a6882316ba3a385a572d21a94228
+  version: 1dfd64f4378ad9dd974bbfbef8e90127dce6aafe
   subpackages:
   - pkg/api
   - pkg/api/errors
@@ -324,30 +351,6 @@ imports:
   - third_party/forked/golang/reflect
   - third_party/forked/golang/template
 testImports:
-- name: github.com/onsi/ginkgo
-  version: 74c678d97c305753605c338c6c78c49ec104b5e7
-  subpackages:
-  - config
-  - ginkgo
-  - ginkgo/convert
-  - ginkgo/interrupthandler
-  - ginkgo/nodot
-  - ginkgo/testrunner
-  - ginkgo/testsuite
-  - ginkgo/watch
-  - internal/codelocation
-  - internal/containernode
-  - internal/failer
-  - internal/leafnodes
-  - internal/remote
-  - internal/spec
-  - internal/specrunner
-  - internal/suite
-  - internal/testingtproxy
-  - internal/writer
-  - reporters
-  - reporters/stenographer
-  - types
 - name: github.com/onsi/gomega
   version: d59fa0ac68bb5dd932ee8d24eed631cdd519efc3
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,7 +6,6 @@ owners:
   email: rob@tigera.io
 import:
 - package: github.com/docopt/docopt-go
-- package: github.com/ghodss/yaml
 - package: github.com/olekukonko/tablewriter
 - package: github.com/docker/engine-api
   version: release/1.12
@@ -21,3 +20,5 @@ import:
 - package: github.com/projectcalico/libcalico-go
   subpackages:
   - lib
+- package: github.com/projectcalico/go-yaml-wrapper
+- package: github.com/projectcalico/go-json

--- a/test-data/policy-bad.yaml
+++ b/test-data/policy-bad.yaml
@@ -1,0 +1,37 @@
+- apiVersion: v1
+  kind: policy
+  metadata:
+    name: policy1
+    testr: 1
+    testq: 2
+    testm: r
+  spec:
+    order: 9999.9999
+    ingress:
+      - action: allow
+        protocol: udp
+        icmp:
+          type: 100
+          code: 100
+        source:
+          tag: web
+          net: 1.2.3.44/10
+          selector:
+          ports: [1,2,3,4]
+        destination:
+          tag: database
+          net: 10.20.30.40/32
+          selector:
+          ports:
+    egress:
+      - action: deny
+        protocol: tcp
+        thing: 2
+        source:
+          notTag: abcd
+          notNet: aa:bb:cc::ff/100
+          notSelector: 
+          notPorts: [100]
+    selector:
+    thing2: 3
+    thing: w

--- a/test-data/policy-invalid-field.yaml
+++ b/test-data/policy-invalid-field.yaml
@@ -13,13 +13,13 @@
         source:
           tag: web
           net: 1.2.3.4/10
-          selector: has(THING_THING8)
+          selector:
           ports: [1,2,3,4]
         destination:
           tag: database
           net: 10.20.30.40/32
           selector:
-          ports:
+        ports:
     egress:
       - action: deny
         protocol: tcp
@@ -27,14 +27,8 @@
           notTag: abcd
           notNet: aa:bb:cc::ff/100
           notSelector: 
-          notPorts: [100,"3:4",65535,"10:20","20:40"]
+          notPorts: [100]
     selector:
-- apiVersion: v1
-  kind: policy
-  metadata:
-    name: policy2
-  spec:
-    order: 0
 - apiVersion: v1
   kind: hostEndpoint
   metadata:
@@ -45,44 +39,13 @@
   spec:
     interfaceName: eth0
     profiles: [prof1, prof2]
-    expectedIPs: [1.2.3.4, "00:bb::aa"]
 - apiVersion: v1
   kind: profile
   metadata:
     name: profile1
-    labels:
-      type: database
-      THING4: VALUE10/2-F
-    tags: [a, b, c, a1, update]
   spec:
+    tags: [a, b, c, a1]
     ingress:
-      - action: deny
+    - action: deny
     egress:
-      - action: deny
-- apiVersion: v1
-  kind: profile
-  metadata:
-    name: empty
-  spec:
-    ingress:
-      - action: deny
-- apiVersion: v1
-  kind: bgpPeer
-  metadata:
-    scope: global
-    peerIP: 1.2.3.4
-  spec:
-    asNumber: 1234
-- apiVersion: v1
-  kind: bgpPeer
-  metadata:
-    scope: node
-    node: fred
-    peerIP: 1.3.5.6
-  spec:
-    asNumber: "1.10"
-- apiVersion: v1
-  kind: ipPool
-  metadata:
-    cidr: 10.10.0.0/16
-
+    - action: deny

--- a/tests/st/bgp/test_global_config.py
+++ b/tests/st/bgp/test_global_config.py
@@ -32,7 +32,7 @@ class TestBGP(TestBase):
         """
         with DockerHost('host', start_calico=False, dind=False) as host:
             # Check default AS command
-            self.assertEquals(host.calicoctl("config get asNumber"), "64511")
+            self.assertEquals(host.calicoctl("config get asNumber"), "64512")
             host.calicoctl("config set asNumber 12345")
             self.assertEquals(host.calicoctl("config get asNumber"), "12345")
             with self.assertRaises(CommandExecError):

--- a/tests/st/calicoctl/test_crud.py
+++ b/tests/st/calicoctl/test_crud.py
@@ -625,54 +625,54 @@ class TestCreateFromFile(TestBase):
                    'selector': ""}},
          ),
         #  https://github.com/projectcalico/libcalico-go/issues/230
-        # ("policy",
-        #  {'apiVersion': 'v1',
-        #   'kind': 'policy',
-        #   'metadata': {'name': 'policy1', },
-        #   'spec': {'egress': [{'action': 'deny',
-        #                        'protocol': 'tcp',
-        #                        'destination': {},
-        #                        'source': {
-        #                            'notNet': 'aa:bb:cc:ff::/100',
-        #                            'notPorts': [100],
-        #                            'notTag': 'abcd'}}],
-        #            'ingress': [{'action': 'allow',
-        #                         'destination': {
-        #                             'net': '10.20.30.40/32',
-        #                             'tag': 'database'},
-        #                         'icmp': {'code': 100,
-        #                                  'type': 10},
-        #                         'protocol': 'udp',
-        #                         'source': {
-        #                             'net': '1.2.0.0/16',
-        #                             'ports': [1, 2, 3, 4],
-        #                             'tag': 'web'}}],
-        #            'order': 6543215.321,
-        #            'selector': ''}},
-        #  {'apiVersion': 'v1',
-        #   'kind': 'policy',
-        #   'metadata': {'name': 'policy1'},
-        #   'spec': {'egress': [{'action': 'deny',
-        #                        'protocol': 'tcp',
-        #                        'destination': {},
-        #                        'source': {
-        #                            'notNet': 'aa:bb:cc::/100',
-        #                            'notPorts': [100],
-        #                            'notTag': 'abcd'}}],
-        #            'ingress': [{'action': 'allow',
-        #                         'destination': {
-        #                             'net': '10.20.30.40/32',
-        #                             'tag': 'database'},
-        #                         'icmp': {'code': 100,
-        #                                  'type': 10},
-        #                         'protocol': 'udp',
-        #                         'source': {
-        #                             'net': '1.2.3.0/24',
-        #                             'ports': [1, 2, 3, 4],
-        #                             'tag': 'web'}}],
-        #            'order': 100000,
-        #            'selector': ""}},
-        #  ),
+        ("policy",
+          {'apiVersion': 'v1',
+           'kind': 'policy',
+           'metadata': {'name': 'policy1', },
+           'spec': {'egress': [{'action': 'deny',
+                                'protocol': 'tcp',
+                                'destination': {},
+                                'source': {
+                                    'notNet': 'aa:bb:cc:ff::/100',
+                                    'notPorts': [100],
+                                    'notTag': 'abcd'}}],
+                    'ingress': [{'action': 'allow',
+                                 'destination': {
+                                     'net': '10.20.30.40/32',
+                                     'tag': 'database'},
+                                 'icmp': {'code': 100,
+                                          'type': 10},
+                                 'protocol': 'udp',
+                                 'source': {
+                                     'net': '1.2.0.0/16',
+                                     'ports': [1, 2, 3, 4],
+                                     'tag': 'web'}}],
+                    'order': 6543215.321,
+                    'selector': ''}},
+          {'apiVersion': 'v1',
+           'kind': 'policy',
+           'metadata': {'name': 'policy1'},
+           'spec': {'egress': [{'action': 'deny',
+                                'protocol': 'tcp',
+                                'destination': {},
+                                'source': {
+                                    'notNet': 'aa:bb:cc::/100',
+                                    'notPorts': [100],
+                                    'notTag': 'abcd'}}],
+                    'ingress': [{'action': 'allow',
+                                 'destination': {
+                                     'net': '10.20.30.40/32',
+                                     'tag': 'database'},
+                                 'icmp': {'code': 100,
+                                          'type': 10},
+                                 'protocol': 'udp',
+                                 'source': {
+                                     'net': '1.2.3.0/24',
+                                     'ports': [1, 2, 3, 4],
+                                     'tag': 'web'}}],
+                    'order': 100000,
+                    'selector': ""}},
+        ),
         ("ipPool",
          {'apiVersion': 'v1',
           'kind': 'ipPool',
@@ -791,7 +791,7 @@ class InvalidData(TestBase):
                        'metadata': {'node': 'Node1',
                                     'peerIP': '192.168.0.250',
                                     'scope': 'node'},
-                       'spec': {'asNumber': 64511}
+                       'spec': {'asNumber': 64513}
                    }),
                    ("bgpPeer-invalidASnum", {
                        'apiVersion': 'v1',
@@ -808,7 +808,7 @@ class InvalidData(TestBase):
                        'metadata': {'node': 'Node1',
                                     'peerIP': '192.168.0.256',
                                     'scope': 'node'},
-                       'spec': {'asNumber': 64511}
+                       'spec': {'asNumber': 64513}
                    }),
                    ("bgpPeer-apiversion", {
                        'apiVersion': 'v7',
@@ -816,7 +816,7 @@ class InvalidData(TestBase):
                        'metadata': {'node': 'Node1',
                                     'peerIP': '192.168.0.250',
                                     'scope': 'node'},
-                       'spec': {'asNumber': 64511}
+                       'spec': {'asNumber': 64513}
                    }),
                    ("bgpPeer-invalidIpv6", {
                        'apiVersion': 'v1',
@@ -834,26 +834,36 @@ class InvalidData(TestBase):
                                     'scope': 'node'},
                        'spec': {'asNumber': 64590}
                    }),
+                   # See issue https://github.com/projectcalico/libcalico-go/issues/248
+                   ("bgpPeer-unrecognisedfield", {
+                       'apiVersion': 'v1',
+                       'kind': 'bgpPeer',
+                       'metadata': {'node': 'Node2',
+                                    'peerIP': 'fd5f::6:ee',
+                                    'scope': 'node'},
+                       'spec': {'asNumber': 64590,
+                                'unknown': 'thing'}
+                   }),
                    # See issue https://github.com/projectcalico/libcalico-go/issues/222
-                   # ("bgpPeer-longname", {
-                   #     'apiVersion': 'v1',
-                   #     'kind': 'bgpPeer',
-                   #     'metadata': {'node':
-                   #                      'TestTestTestTestTestTestTestTestTestTestTest'
-                   #                      'TestTestTestTestTestTestTestTestTestTestTest'
-                   #                      'TestTestTestTestTestTestTestTestTestTestTest'
-                   #                      'TestTestTestTestTestTestTestTestTestTestTest'
-                   #                      'TestTestTestTestTestTestTestTestTestTestTest'
-                   #                      'TestTestTestTestTestTestTestTestTestTestTest'
-                   #                      'TestTestTestTestTestTestTestTestTestTestTest'
-                   #                      'TestTestTestTestTestTestTestTestTestTestTest'
-                   #                      'TestTestTestTestTestTestTestTestTestTestTest'
-                   #                      'TestTestTestTestTestTestTestTestTestTestTest'
-                   #                      'TestTestTestTestTestTestTestTestTestTestTest',
-                   #                  'peerIP': 'fd5f::6:ee',
-                   #                  'scope': 'node'},
-                   #     'spec': {'asNumber': 64590}
-                   # }),
+                   ("bgpPeer-longname", {
+                       'apiVersion': 'v1',
+                       'kind': 'bgpPeer',
+                       'metadata': {'node':
+                                        'TestTestTestTestTestTestTestTestTestTestTest'
+                                        'TestTestTestTestTestTestTestTestTestTestTest'
+                                        'TestTestTestTestTestTestTestTestTestTestTest'
+                                        'TestTestTestTestTestTestTestTestTestTestTest'
+                                        'TestTestTestTestTestTestTestTestTestTestTest'
+                                        'TestTestTestTestTestTestTestTestTestTestTest'
+                                        'TestTestTestTestTestTestTestTestTestTestTest'
+                                        'TestTestTestTestTestTestTestTestTestTestTest'
+                                        'TestTestTestTestTestTestTestTestTestTestTest'
+                                        'TestTestTestTestTestTestTestTestTestTestTest'
+                                        'TestTestTestTestTestTestTestTestTestTestTest',
+                                    'peerIP': 'fd5f::6:ee',
+                                    'scope': 'node'},
+                       'spec': {'asNumber': 64590}
+                   }),
                    ("hostEndpoint-invalidInterface", {
                        'apiVersion': 'v1',
                        'kind': 'hostEndpoint',
@@ -1059,7 +1069,7 @@ class InvalidData(TestBase):
                        'metadata': {'node': 'Node1',
                                     'peerIP': '192.168.0.250',
                                     'scope': 'node'},
-                       'spec': {'asNumber': 64511}},
+                       'spec': {'asNumber': 64513}},
                        {'apiVersion': 'v1',
                         'kind': 'profile',
                         'metadata': {


### PR DESCRIPTION
Fixes https://github.com/projectcalico/libcalico-go/issues/230
Fixes https://github.com/projectcalico/libcalico-go/issues/248

This PR relies on forks of three other libraries, these forks provide improved error details, swap Float32 with Float64 support, strict validation of unexpected fields.   Please also see the following PRs:
 
https://github.com/projectcalico/go-yaml/pull/1
https://github.com/projectcalico/go-yaml-wrapper/pull/1