### PR TITLE
reinstate directory (accidentally removed)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ $(NODE_CONTAINER_BIN_DIR)/calico-bgp-daemon:
 $(NODE_CONTAINER_BIN_DIR)/bird:
 	# This make target actually downloads the bird6 and birdcl binaries too
 	# Copy patched BIRD daemon with tunnel support.
-	$(CURL) -L $(BIRD6_URL) -o bird6
+	$(CURL) -L $(BIRD6_URL) -o $(@D)/bird6
 	$(CURL) -L $(BIRDCL_URL) -o $(@D)/birdcl
 	$(CURL) -L $(BIRD_URL) -o $@
 	chmod +x $(@D)/*


### PR DESCRIPTION
Accidentally removed in this comment (cut error .... when it should have been a copy)  

https://github.com/projectcalico/calico-containers/commit/fe16ac2e49cd15ba32a2bd5393a6c6c8127abb52