### PR TITLE
Swap parm order round for docker logs command in calicoctl node run

### DIFF
--- a/calicoctl/commands/node/run.go
+++ b/calicoctl/commands/node/run.go
@@ -341,7 +341,7 @@ Description:
 
 	// Create the command to follow the docker logs for the calico/node
 	fmt.Println("Container started, checking progress logs.")
-	logCmd := exec.Command("docker", "logs", "calico-node", "--follow")
+	logCmd := exec.Command("docker", "logs", "--follow", "calico-node")
 
 	// Get the stdout pipe
 	outPipe, err := logCmd.StdoutPipe()


### PR DESCRIPTION
Spotted error on CoreOS.  Funning calicoctl node run errored and exited, but the calico/node container was running successfully.

Turns out that on the Vagrant CoreOS system, the version of Docker does not allow the `--follow` flag to appear after the container name in the `docker logs` command.

Just need to swap it round in the command.